### PR TITLE
feat: `StoryboardInstantiable` 및 `NSObject+Nib`, `NSObject+ID` 확장 코드 구현

### DIFF
--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1C787DA62E392091005A75D6 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1C787DA52E392091005A75D6 /* FirebaseCrashlytics */; };
+		C76CA76E2E3AE2110040EF75 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = C76CA76D2E3AE2110040EF75 /* FirebaseAnalyticsCore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,7 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C787DA62E392091005A75D6 /* FirebaseCrashlytics in Frameworks */,
+				C76CA76E2E3AE2110040EF75 /* FirebaseAnalyticsCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,6 +75,7 @@
 			children = (
 				C76490992E3790170062054D /* Health */,
 				C76490C42E3790410062054D /* HealthTests */,
+				C76CA76C2E3AE2110040EF75 /* Frameworks */,
 				C76490982E3790170062054D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -88,6 +89,13 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		C76CA76C2E3AE2110040EF75 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -98,7 +106,6 @@
 				C76490932E3790170062054D /* Sources */,
 				C76490942E3790170062054D /* Frameworks */,
 				C76490952E3790170062054D /* Resources */,
-				1C787DA72E39213A005A75D6 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -109,7 +116,7 @@
 			);
 			name = Health;
 			packageProductDependencies = (
-				1C787DA52E392091005A75D6 /* FirebaseCrashlytics */,
+				C76CA76D2E3AE2110040EF75 /* FirebaseAnalyticsCore */,
 			);
 			productName = Health;
 			productReference = C76490972E3790170062054D /* Health.app */;
@@ -169,7 +176,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				C76491E52E37A0C30062054D /* XCRemoteSwiftPackageReference "TSAlertController-iOS" */,
-				1C787DA42E392091005A75D6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				C76CA76B2E3AE1F70040EF75 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C76490982E3790170062054D /* Products */;
@@ -198,32 +205,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		1C787DA72E39213A005A75D6 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
-				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
-				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C76490932E3790170062054D /* Sources */ = {
@@ -258,7 +239,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JTXDAQ58BH;
+				DEVELOPMENT_TEAM = 4DQM269FVB;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -272,6 +253,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.est-3rd.Health";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -292,7 +274,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JTXDAQ58BH;
+				DEVELOPMENT_TEAM = 4DQM269FVB;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -306,6 +288,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.est-3rd.Health";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -354,7 +337,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 4DQM269FVB;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -378,7 +361,6 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -436,7 +418,6 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
@@ -517,14 +498,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1C787DA42E392091005A75D6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.0.0;
-			};
-		};
 		C76491E52E37A0C30062054D /* XCRemoteSwiftPackageReference "TSAlertController-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rlarjsdn3/TSAlertController-iOS.git";
@@ -533,13 +506,21 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		C76CA76B2E3AE1F70040EF75 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1C787DA52E392091005A75D6 /* FirebaseCrashlytics */ = {
+		C76CA76D2E3AE2110040EF75 /* FirebaseAnalyticsCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1C787DA42E392091005A75D6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseCrashlytics;
+			package = C76CA76B2E3AE1F70040EF75 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Health.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Health.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -22,7 +22,7 @@
     {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
         "revision" : "4e62da1e5e6baf61674d3f5ae23d6d60c19f9c4a",
         "version" : "12.0.0"

--- a/Health/Application/AppDelegate.swift
+++ b/Health/Application/AppDelegate.swift
@@ -6,7 +6,8 @@
 //
 
 import UIKit
-import FirebaseCore
+
+import Firebase
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Health/Core/Protocols/StoryboardInstantiable.swift
+++ b/Health/Core/Protocols/StoryboardInstantiable.swift
@@ -7,38 +7,42 @@
 
 import UIKit
 
-///
+/// 스토리보드에서 인스턴스를 생성할 수 있도록 하는 프로토콜입니다.
 protocol StoryboardInstantiable {
 
+    /// 주어진 이름의 스토리보드를 반환합니다.
     ///
+    /// - Parameter name: 스토리보드 이름입니다. `nil`일 경우 기본 이름(`storyboardName`)이 사용됩니다.
+    /// - Returns: `UIStoryboard` 인스턴스를 반환합니다.
     static func storyboard(name: String?) -> UIStoryboard
 }
 
+@MainActor
 extension StoryboardInstantiable where Self: UIViewController {
 
-
-    /// <#Description#>
+    /// 기본 스토리보드 이름입니다.
+    ///
+    /// 클래스 이름을 기준으로 자동 생성되며, 모듈명을 제외한 클래스 이름이 사용됩니다.
     static var storyboardName: String {
         NSStringFromClass(Self.self)
             .components(separatedBy: ".")
             .last!
     }
 
-
-    /// <#Description#>
-    /// - Parameter name: <#name description#>
-    /// - Returns: <#description#>
+    /// 주어진 이름 또는 기본 이름을 사용해 스토리보드를 생성합니다.
+    ///
+    /// - Parameter name: 스토리보드 이름입니다. `nil`일 경우 `storyboardName`이 사용됩니다.
+    /// - Returns: 해당 이름의 `UIStoryboard` 인스턴스를 반환합니다.
     static func storyboard(name: String? = nil) -> UIStoryboard {
         let bundle = Bundle(for: Self.self)
         return UIStoryboard(name: name ?? storyboardName, bundle: bundle)
     }
 
-
-    /// <#Description#>
-    /// - Parameters:
-    ///   - name: <#name description#>
-    ///   - identifier: <#identifier description#>
-    /// - Returns: <#description#>
+    /// 스토리보드로부터 초기 뷰 컨트롤러를 인스턴스화합니다.
+    ///
+    /// - Parameter name: 사용할 스토리보드 이름입니다. `nil`일 경우 `storyboardName`이 사용됩니다.
+    /// - Returns: 초기 뷰 컨트롤러로 지정된 `Self` 타입 인스턴스를 반환합니다.
+    /// - Note: 초기 뷰 컨트롤러가 존재하지 않거나 형변환에 실패할 경우 앱이 종료됩니다.
     static func instantiateIntialViewController(name: String? = nil) -> Self {
         guard let vc = storyboard(name: name).instantiateInitialViewController() as? Self
         else { fatalError("could not load \(Self.self)") }

--- a/Health/Core/Protocols/StoryboardInstantiable.swift
+++ b/Health/Core/Protocols/StoryboardInstantiable.swift
@@ -1,0 +1,47 @@
+//
+//  StoryboardInstantiable.swift
+//  Health
+//
+//  Created by 김건우 on 7/31/25.
+//
+
+import UIKit
+
+///
+protocol StoryboardInstantiable {
+
+    ///
+    static func storyboard(name: String?) -> UIStoryboard
+}
+
+extension StoryboardInstantiable where Self: UIViewController {
+
+
+    /// <#Description#>
+    static var storyboardName: String {
+        NSStringFromClass(Self.self)
+            .components(separatedBy: ".")
+            .last!
+    }
+
+
+    /// <#Description#>
+    /// - Parameter name: <#name description#>
+    /// - Returns: <#description#>
+    static func storyboard(name: String? = nil) -> UIStoryboard {
+        let bundle = Bundle(for: Self.self)
+        return UIStoryboard(name: name ?? storyboardName, bundle: bundle)
+    }
+
+
+    /// <#Description#>
+    /// - Parameters:
+    ///   - name: <#name description#>
+    ///   - identifier: <#identifier description#>
+    /// - Returns: <#description#>
+    static func instantiateIntialViewController(name: String? = nil) -> Self {
+        guard let vc = storyboard(name: name).instantiateInitialViewController() as? Self
+        else { fatalError("could not load \(Self.self)") }
+        return vc
+    }
+}

--- a/Health/Core/Utils/NSObject+ID.swift
+++ b/Health/Core/Utils/NSObject+ID.swift
@@ -1,0 +1,8 @@
+//
+//  NSObject+ID.swift
+//  Health
+//
+//  Created by 김건우 on 7/31/25.
+//
+
+import Foundation

--- a/Health/Core/Utils/NSObject+ID.swift
+++ b/Health/Core/Utils/NSObject+ID.swift
@@ -6,3 +6,16 @@
 //
 
 import Foundation
+
+extension NSObject {
+
+    /// 현재 객체의 클래스 이름을 문자열로 반환합니다.
+    ///
+    /// 네임스페이스(모듈 이름)를 제외한 클래스 이름만 반환되며,
+    /// 주로 식별자나 리유즈 아이디 등으로 활용할 수 있습니다.
+    var id: String {
+        NSStringFromClass(Self.self)
+            .components(separatedBy: ".")
+            .last!
+    }
+}

--- a/Health/Core/Utils/NSObject+Nib.swift
+++ b/Health/Core/Utils/NSObject+Nib.swift
@@ -5,4 +5,19 @@
 //  Created by 김건우 on 7/28/25.
 //
 
-import Foundation
+import UIKit
+
+@MainActor
+extension NSObject {
+
+    /// 클래스와 동일한 이름을 가진 Nib 파일을 로드합니다.
+    ///
+    /// - Returns: 현재 클래스 이름을 기준으로 생성된 `UINib` 인스턴스를 반환합니다.
+    ///            Nib 파일은 해당 클래스가 속한 번들에서 로드됩니다.
+    var nib: UINib {
+        UINib(
+            nibName: String(describing: Self.self),
+            bundle: Bundle(for: Self.self)
+        )
+    }
+}

--- a/Health/Core/Utils/NSObject+Nib.swift
+++ b/Health/Core/Utils/NSObject+Nib.swift
@@ -1,5 +1,5 @@
 //
-//  UIImage+Resize.swift
+//  NSObject+Nib.swift
 //  Health
 //
 //  Created by 김건우 on 7/28/25.


### PR DESCRIPTION
## #️⃣ 이슈번호

close #5 

---

## ✅ 변경사항

####  UIStoryboardInstantiable 

- UIStoryboard에서 쉽게 `UIViewController` 객체를 생성할 수 있도록 `UIStoryboardInstantiable` 프로토콜 (기본) 구현 코드 작성

- 예를 들어, 아래 예제는 Main 스토리보드에 정의되어 있는 initialViewController를 로드하는 코드입니다.

```swift
let vc = MainViewController.instantitateIntialViewController(name: "Main")
```

- 하지만, 세그웨이를 통해 화면 간 전환을 할 것이므로, 자주 쓰이는 코드는 아니라 생각합니다. 사용할 일이 있을까 해서 작성하였습니다.

#### NSObject+Nib, NSObject+ID

- 뷰 및 스토리보드 객체에 해당하는 UINib 객체를 불러와주는 코드 구현, 클래스 이름으로 문자열 ID 값을 생성해주는 코드 구현

```swift
collectionView.register(nib: MainCollectionViewCell.nib, identifier: MainCollectionViewCell.id)
```

- 모두 컬렉션 뷰에 셀의 Nib 및 ID 등록을 편하게 하려는 목적으로 작성된 코드입니다.



---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|    |     |

---

### 💜 결과

-
