### PR TITLE
feat: 네트워크 공통 서비스 기본 구조 도입

### DIFF
--- a/Health/Application/Configuration/AppConfiguration.swift
+++ b/Health/Application/Configuration/AppConfiguration.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+
+/// 애플리케이션 전역 설정을 관리하는 구조체
+///
+/// 앱에서 사용되는 공통 설정값들을 중앙에서 관리합니다.
+/// 환경별 설정이나 전역적으로 사용되는 상수값들을 포함합니다.
+///
+/// ## 주요 용도
+/// - API 서버 기본 URL 설정
+/// - 환경별 설정 분리
+/// - 애플리케이션 공통 상수 관리
+///
+/// ## 사용 예시
+/// ```swift
+/// let networkService = NetworkService(baseURL: AppConfiguration.baseURL)
+/// ```
+struct AppConfiguration {
+
+    /// API 서버의 기본 URL
+    ///
+    /// - Note: 강제 언래핑(!)을 사용하므로 URL 문자열이 항상 유효해야 합니다.
+    static let baseURL = URL(string: "https://kdt-api-function.azurewebsites.net")!
+}

--- a/Health/Core/Network/APIEndpoint.swift
+++ b/Health/Core/Network/APIEndpoint.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// API 엔드포인트를 정의하는 열거형
+///
+/// 애플리케이션에서 사용하는 모든 API 엔드포인트를 캡슐화하고,
+/// 각 엔드포인트의 경로, HTTP 메서드, 쿼리 파라미터, 요청 본문을 관리합니다.
+enum APIEndpoint {
+
+    /// 질문을 전송하는 엔드포인트
+    /// - Parameters:
+    ///   - content: 질문 내용
+    ///   - clientID: 클라이언트 식별자
+    case ask(content: String, clientID: String)
+
+    /// 스트리밍 방식으로 질문을 전송하는 엔드포인트
+    /// - Parameters:
+    ///   - content: 질문 내용
+    ///   - clientID: 클라이언트 식별자
+    case askStreaming(content: String, clientID: String)
+
+    /// 상태를 초기화하는 엔드포인트
+    /// - Parameter clientID: 클라이언트 식별자
+    case resetState(clientID: String)
+
+    /// API 엔드포인트의 경로를 반환합니다
+    ///
+    /// - Returns: 각 엔드포인트에 해당하는 URL 경로 문자열
+    var path: String {
+        switch self {
+            case .ask:
+                return "/api/v1/question"
+            case .askStreaming:
+                return "/api/v1/question/sse-streaming"
+            case .resetState:
+                return "/api/v1/reset-state"
+        }
+    }
+
+    /// HTTP 메서드를 반환합니다
+    ///
+    /// - Returns: 각 엔드포인트에 해당하는 HTTP 메서드 문자열
+    var method: String {
+        switch self {
+            case .resetState:
+                return "DELETE"
+            default:
+                return "GET"
+        }
+    }
+
+    /// URL 쿼리 파라미터를 반환합니다
+    ///
+    /// - Returns: 각 엔드포인트에 필요한 쿼리 파라미터 배열, 없을 경우 nil
+    var queryItems: [URLQueryItem]? {
+        switch self {
+            case let .ask(content, clientID),
+                let .askStreaming(content, clientID):
+                return [
+                    URLQueryItem(name: "content", value: content),
+                    URLQueryItem(name: "client_id", value: clientID)
+                ]
+            default:
+                return nil
+        }
+    }
+
+    /// HTTP 요청 본문 데이터를 반환합니다
+    ///
+    /// - Returns: 각 엔드포인트에 필요한 요청 본문 데이터, 없을 경우 nil
+    var body: Data? {
+        switch self {
+            case let .resetState(clientID):
+                let json: [String: String] = ["client_id": clientID]
+                return try? JSONSerialization.data(withJSONObject: json)
+            default:
+                return nil
+        }
+    }
+}

--- a/Health/Core/Network/HTTPValidationError.swift
+++ b/Health/Core/Network/HTTPValidationError.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// HTTP 검증 오류 응답을 나타내는 구조체
+///
+/// 서버에서 422 상태 코드와 함께 반환되는 검증 오류 정보를 파싱하기 위해 사용됩니다.
+/// 일반적으로 요청 데이터의 형식이나 내용이 올바르지 않을 때 발생합니다.
+struct HTTPValidationError: Decodable {
+
+    /// 발생한 검증 오류들의 상세 정보 배열
+    let detail: [ValidationError]
+}
+
+/// 개별 검증 오류의 상세 정보를 나타내는 구조체
+///
+/// 각 검증 오류에 대한 위치, 메시지, 타입 정보를 포함합니다.
+struct ValidationError: Decodable {
+
+    /// 오류가 발생한 필드의 위치 경로
+    let loc: [String]
+
+    /// 오류에 대한 설명 메시지
+    let msg: String
+
+    /// 오류의 타입
+    let type: String
+}

--- a/Health/Core/Network/NetworkError.swift
+++ b/Health/Core/Network/NetworkError.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// 네트워크 관련 오류를 정의하는 열거형
+///
+/// 네트워크 요청 과정에서 발생할 수 있는 다양한 오류 상황을 캡슐화합니다.
+/// 각 케이스는 특정한 오류 상황을 나타내며, 적절한 오류 처리를 위해 사용됩니다.
+enum NetworkError: Error {
+
+    /// 잘못된 URL로 인한 오류
+    ///
+    /// URL 구성이 실패했거나 유효하지 않은 URL일 때 발생합니다.
+    case badURL
+
+    /// 네트워크 요청 실패 오류
+    ///
+    /// - Parameter Error: 원본 오류 정보
+    ///
+    /// 네트워크 연결 문제, 타임아웃 등으로 요청이 실패했을 때 발생합니다.
+    case requestFailed(Error)
+
+    /// 유효하지 않은 응답 오류
+    ///
+    /// HTTP 응답이 예상과 다르거나 처리할 수 없는 형태일 때 발생합니다.
+    case invalidResponse
+
+    /// 응답 데이터 디코딩 실패 오류
+    ///
+    /// - Parameter Error: 디코딩 실패의 원본 오류 정보
+    ///
+    /// JSON 디코딩 과정에서 오류가 발생했을 때 사용됩니다.
+    case decodingFailed(Error)
+
+    /// 서버 검증 실패 오류
+    ///
+    /// - Parameter String: 검증 실패 메시지
+    ///
+    /// 서버에서 422 상태 코드와 함께 검증 오류를 반환했을 때 발생합니다.
+    case validationFailed(String)
+
+    /// 알 수 없는 오류
+    ///
+    /// 위의 카테고리에 속하지 않는 예상치 못한 오류 상황에 사용됩니다.
+    case unknown
+}

--- a/Health/Core/Network/NetworkService.swift
+++ b/Health/Core/Network/NetworkService.swift
@@ -3,7 +3,7 @@ import Foundation
 /// 네트워크 요청을 처리하는 서비스의 프로토콜
 ///
 /// 네트워크 서비스의 기본 인터페이스를 정의하며, 테스트 목적으로 모킹할 수 있도록 합니다.
-protocol NetworkServicing {
+protocol DefaultNetworkService {
 
     /// 지정된 엔드포인트로 네트워크 요청을 수행합니다
     ///
@@ -26,7 +26,7 @@ protocol NetworkServicing {
 /// let endpoint = APIEndpoint.ask(content: "안녕하세요", clientID: "client123")
 /// let response = try await networkService.request(endpoint: endpoint, as: ResponseModel.self)
 /// ```
-final class NetworkService: NetworkServicing {
+final class NetworkService: DefaultNetworkService {
 
     /// API 요청의 기본 URL
     private let baseURL: URL

--- a/Health/Core/Network/NetworkService.swift
+++ b/Health/Core/Network/NetworkService.swift
@@ -70,8 +70,10 @@ final class NetworkService: DefaultNetworkService {
 
         var request = URLRequest(url: finalURL)
         request.httpMethod = endpoint.method
-        request.httpBody = endpoint.body
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body = endpoint.body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)

--- a/Health/Core/Network/NetworkService.swift
+++ b/Health/Core/Network/NetworkService.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// 네트워크 요청을 처리하는 서비스의 프로토콜
+///
+/// 네트워크 서비스의 기본 인터페이스를 정의하며, 테스트 목적으로 모킹할 수 있도록 합니다.
+protocol NetworkServicing {
+
+    /// 지정된 엔드포인트로 네트워크 요청을 수행합니다
+    ///
+    /// - Parameters:
+    ///   - endpoint: 요청할 API 엔드포인트
+    ///   - type: 응답 데이터를 디코딩할 타입
+    /// - Returns: 디코딩된 응답 데이터
+    /// - Throws: 네트워크 오류가 발생할 경우 `NetworkError`를 던집니다
+    func request<T: Decodable>(endpoint: APIEndpoint, as type: T.Type) async throws -> T
+}
+
+/// 네트워크 요청을 처리하는 구체적인 구현체
+///
+/// `URLSession`을 사용하여 실제 HTTP 요청을 수행하고,
+/// 응답을 적절한 타입으로 디코딩하여 반환합니다.
+///
+/// ## 사용 예시
+/// ```swift
+/// let networkService = NetworkService()
+/// let endpoint = APIEndpoint.ask(content: "안녕하세요", clientID: "client123")
+/// let response = try await networkService.request(endpoint: endpoint, as: ResponseModel.self)
+/// ```
+final class NetworkService: NetworkServicing {
+
+    /// API 요청의 기본 URL
+    private let baseURL: URL
+
+    /// NetworkService 인스턴스를 초기화합니다
+    ///
+    /// - Parameter baseURL: API 서버의 기본 URL (기본값: AppConfiguration.baseURL)
+    init(baseURL: URL = AppConfiguration.baseURL) {
+        self.baseURL = baseURL
+    }
+
+    /// 지정된 엔드포인트로 네트워크 요청을 수행합니다
+    ///
+    /// 이 메서드는 다음과 같은 과정을 거쳐 요청을 처리합니다:
+    /// 1. URL 구성 및 검증
+    /// 2. HTTP 요청 설정
+    /// 3. 네트워크 요청 전송
+    /// 4. 응답 상태 코드 검증
+    /// 5. JSON 디코딩
+    ///
+    /// - Parameters:
+    ///   - endpoint: 요청할 API 엔드포인트
+    ///   - type: 응답 데이터를 디코딩할 타입
+    /// - Returns: 디코딩된 응답 데이터
+    /// - Throws: 다음과 같은 `NetworkError`를 던질 수 있습니다:
+    ///   - `badURL`: URL 구성 실패
+    ///   - `requestFailed`: 네트워크 요청 실패
+    ///   - `invalidResponse`: 유효하지 않은 HTTP 응답
+    ///   - `decodingFailed`: JSON 디코딩 실패
+    ///   - `validationFailed`: 서버 검증 실패 (422 상태 코드)
+    func request<T: Decodable>(endpoint: APIEndpoint, as type: T.Type) async throws -> T {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(endpoint.path), resolvingAgainstBaseURL: false) else {
+            throw NetworkError.badURL
+        }
+
+        components.queryItems = endpoint.queryItems
+
+        guard let finalURL = components.url else {
+            throw NetworkError.badURL
+        }
+
+        var request = URLRequest(url: finalURL)
+        request.httpMethod = endpoint.method
+        request.httpBody = endpoint.body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw NetworkError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+                case 200..<300:
+                    return try JSONDecoder().decode(T.self, from: data)
+
+                case 422:
+                    let validationError = try? JSONDecoder().decode(HTTPValidationError.self, from: data)
+                    let message = validationError?.detail.first?.msg ?? "Validation failed"
+                    throw NetworkError.validationFailed(message)
+
+
+                default:
+                    throw NetworkError.invalidResponse
+            }
+        } catch let decodingError as DecodingError {
+            throw NetworkError.decodingFailed(decodingError)
+        } catch {
+            throw NetworkError.requestFailed(error)
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 변경사항

Alan AI API 요청을 위한 공통 네트워크 서비스 모듈을 구현했습니다.
SSE 및 Mock 대응 이전 단계로, URLSession + Swift Concurrency 기반 구조를 설정했습니다.

## 📝 참고

### 향후 필요 작업

- Mock 데이터 대응
- SSE 스트리밍 응답 대응
- Alan AI 종속성 분리 및 추상화

## 링크

- [태스크 (노션)](https://www.notion.so/oreumi/241ebaa8982b80838cc7d65426b242c5?source=copy_link)