### PR TITLE
fix: 오버라이드 메소드 버전 지정로 인한 빌드 에러 수정

### DIFF
--- a/Health/Core/ViewControllers/CoreGradientViewController.swift
+++ b/Health/Core/ViewControllers/CoreGradientViewController.swift
@@ -23,7 +23,6 @@ class CoreGradientViewController: CoreViewController {
 		updateGradientFrameIfNeeded()
 	}
 	
-	@available(iOS 13.0, *)
 	override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
 		super.traitCollectionDidChange(previousTraitCollection)
 		


### PR DESCRIPTION
## 변경사항
- 버전 지정 제거

## 해당 빌드 에러에 대한 코파일럿 답변

The build is failing due to the following error in Health/Core/ViewControllers/CoreGradientViewController.swift at line 27:

error: overriding 'traitCollectionDidChange' must be as available as declaration it overrides

This happens because you added @available(iOS 13.0, *) to your override of traitCollectionDidChange, but the base method in UIViewController is available from iOS 8.0. Overridden methods must be at least as available as the base declaration.

To fix this, remove the @available(iOS 13.0, *) attribute from your override. The corrected code should look like:

```swift
override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
    super.traitCollectionDidChange(previousTraitCollection)
    if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
        currentTraitCollection = traitCollection
        handleThemeChange(previousTraitCollection: previousTraitCollection)
    }
}
```

This will resolve the build error and allow the job to succeed. You can view the relevant file here (ref: 35fb62336cf7e763c8e8e76ede4bc3886d27570f).

---

빌드 실패 원인은 traitCollectionDidChange 메서드를 @available(iOS 13.0, *) 속성과 함께 오버라이드했기 때문입니다.
하지만 이 메서드는 상위 클래스인 UIViewController에서 더 넓은 범위(iOS 8.0 이상)에서 사용할 수 있도록 정의되어 있습니다.
Swift에서는 메서드를 오버라이드할 때, 오버라이드된 메서드의 접근 가능 범위가 상위 선언보다 좁으면 안 됩니다.
즉, 상위 메서드가 iOS 8부터 가능하다면, 오버라이드한 메서드도 최소한 iOS 8부터는 가능해야 합니다.

## 테스트
- 빌드 성공 확인
<img width="847" height="133" alt="image" src="https://github.com/user-attachments/assets/fe994704-a81c-4853-bf90-4ee313e19a6d" />
