### PR TITLE
feat: Secrets.xcconfig와 Info.plist 연동으로 API 키 보안 관리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ xcuserdata/
 *.xccheckout
 *.xcconfig
 
+# API Keys 
+Secrets.xcconfig
+Resources/Secrets.xcconfig
+
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
 DerivedData/

--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -237,6 +237,8 @@
 /* Begin XCBuildConfiguration section */
 		C76490AB2E3790180062054D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = C76490992E3790170062054D /* Health */;
+			baseConfigurationReferenceRelativePath = Resources/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -272,6 +274,8 @@
 		};
 		C76490AC2E3790180062054D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = C76490992E3790170062054D /* Health */;
+			baseConfigurationReferenceRelativePath = Resources/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Health/Resources/Info.plist
+++ b/Health/Resources/Info.plist
@@ -21,5 +21,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>AlanCurrentClientID</key>
+	<string>$(CURRENT_CLIENT_ID)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## #️⃣ 이슈번호

>  해당 없음 (팀 API 키 관리 설정)

---

## ✅ 변경사항

- Secrets.xcconfig에서 API 키를 안전하게 읽어오는 기능 구현
- Info.plist의 `AlanCurrentClientID` 값을 Bundle에서 읽어와 반환

---

## 🧪 테스트시 유의 사항

- **Secrets.xcconfig 파일이 필요합니다** (별도 공유 예정)
- Info.plist에 `AlanCurrentClientID` 키 설정 확인 필요
- 프로젝트 Configuration에 Secrets.xcconfig 연결 확인
- 빌드 전 xcconfig 설정이 올바른지 검증 필요

---

## 📝 참고

- `AppConfiguration.clientID` 프로퍼티 라고 AppConfiguration 코드 파일에 clientID 키 설정하는 것 코드 작업자 분이 추가해주세요.

```swift
// 사용 예시
let endpoint = APIEndpoint.ask(
    content: "테스트 질문",
    clientID: AppConfiguration.clientID
)
```
