### PR TITLE
feat: Alan API 응답 모델 및 뷰모델 추가

### DIFF
--- a/Health/Application/Configuration/AppConfiguration.swift
+++ b/Health/Application/Configuration/AppConfiguration.swift
@@ -27,4 +27,8 @@ struct AppConfiguration {
     ///
     /// - Note: 강제 언래핑(!)을 사용하므로 URL 문자열이 항상 유효해야 합니다.
     static let baseURL = URL(string: "https://kdt-api-function.azurewebsites.net")!
+
+    static var clientID: String {
+        Bundle.main.infoDictionary?["CURRENT_CLIENT_ID"] as? String ?? "unknown"
+    }
 }

--- a/Health/Application/Configuration/AppConfiguration.swift
+++ b/Health/Application/Configuration/AppConfiguration.swift
@@ -28,6 +28,14 @@ struct AppConfiguration {
     /// - Note: 강제 언래핑(!)을 사용하므로 URL 문자열이 항상 유효해야 합니다.
     static let baseURL = URL(string: "https://kdt-api-function.azurewebsites.net")!
 
+    /// 현재 앱의 클라이언트 식별자
+    ///
+    /// Info.plist의 `CURRENT_CLIENT_ID` 키에서 클라이언트 ID를 가져옵니다.
+    /// 이 값은 API 호출 시 클라이언트를 식별하거나 환경별 설정을 구분하는 데 사용됩니다.
+    ///
+    /// - Returns: Info.plist에 설정된 클라이언트 ID 문자열. 값이 없으면 "unknown"을 반환합니다.
+    ///
+    /// - **Important**: Info.plist에 `CURRENT_CLIENT_ID` 키가 올바르게 설정되어 있는지 확인하세요.
     static var clientID: String {
         Bundle.main.infoDictionary?["CURRENT_CLIENT_ID"] as? String ?? "unknown"
     }

--- a/Health/Model/Alan/AlanQuestionResponse.swift
+++ b/Health/Model/Alan/AlanQuestionResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct AlanQuestionResponse: Decodable {
+    let action: Action
+    let content: String
+
+    struct Action: Decodable {
+        let name: String
+        let speak: String
+    }
+}

--- a/Health/Model/Alan/AlanResetStateResponse.swift
+++ b/Health/Model/Alan/AlanResetStateResponse.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+struct AlanResetStateResponse: Decodable {}

--- a/Health/Model/Alan/AlanStreamingResponse.swift
+++ b/Health/Model/Alan/AlanStreamingResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct AlanStreamingResponse: Decodable {
+    let type: StreamingType
+    let data: StreamingData
+
+    enum StreamingType: String, Decodable {
+    case `continue`
+    case complete
+    }
+
+    struct StreamingData: Decodable {
+        let content: String
+    }
+}

--- a/Health/Presentation/Alan/AlanViewModel.swift
+++ b/Health/Presentation/Alan/AlanViewModel.swift
@@ -5,22 +5,22 @@ final class AlanViewModel {
 
     @Injected private var networkService: NetworkService
 
-    private(set) var responseText: String = ""
     private(set) var errorMessage: String?
 
     private var clientID: String {
         AppConfiguration.clientID
     }
 
+    var didReceiveResponseText: ((String) -> Void)?
+
     func sendQuestion(_ content: String) async {
         let endpoint = APIEndpoint.ask(content: content, clientID: clientID)
 
         do {
             let response = try await networkService.request(endpoint: endpoint, as: AlanQuestionResponse.self)
-            responseText = response.content
+            didReceiveResponseText?(response.content)
             errorMessage = nil
         } catch {
-            responseText = ""
             errorMessage = error.localizedDescription
         }
     }

--- a/Health/Presentation/Alan/AlanViewModel.swift
+++ b/Health/Presentation/Alan/AlanViewModel.swift
@@ -25,6 +25,8 @@ final class AlanViewModel {
         }
     }
 
+    // TODO: SSE Streaming 추가
+
     func resetAgentState() async {
         let endpoint = APIEndpoint.resetState(clientID: clientID)
 

--- a/Health/Presentation/Alan/AlanViewModel.swift
+++ b/Health/Presentation/Alan/AlanViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+@MainActor
+final class AlanViewModel {
+
+    @Injected private var networkService: NetworkService
+
+    private(set) var responseText: String = ""
+    private(set) var errorMessage: String?
+
+    private var clientID: String {
+        AppConfiguration.clientID
+    }
+
+    func sendQuestion(_ content: String) async {
+        let endpoint = APIEndpoint.ask(content: content, clientID: clientID)
+
+        do {
+            let response = try await networkService.request(endpoint: endpoint, as: AlanQuestionResponse.self)
+            responseText = response.content
+            errorMessage = nil
+        } catch {
+            responseText = ""
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func resetAgentState() async {
+        let endpoint = APIEndpoint.resetState(clientID: clientID)
+
+        do {
+            _ = try await networkService.request(endpoint: endpoint, as: AlanResetStateResponse.self)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Health/Presentation/Base.lproj/Main.storyboard
+++ b/Health/Presentation/Base.lproj/Main.storyboard
@@ -65,11 +65,11 @@
             </objects>
             <point key="canvasLocation" x="-1074" y="930"/>
         </scene>
-        <!--달력-->
+        <!--캘린더-->
         <scene sceneID="Zcw-ob-jgq">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Hb7-NA-4yX" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="달력" image="calendar" catalog="system" id="VCg-9j-J3e"/>
+                    <tabBarItem key="tabBarItem" title="캘린더" image="calendar" catalog="system" id="VCg-9j-J3e"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="juf-sZ-Zbd">
                         <rect key="frame" x="0.0" y="118" width="393" height="44"/>


### PR DESCRIPTION
## 작업내용
- 달력 탭 이름을 "캘린더"로 변경
- Alan API 응답 모델 추가
  - `AlanQuestionResponse.swift`
  - `AlanStreamingResponse.swift`
  - `AlanResetStateResponse.swift`
- Alan API 뷰모델 추가 (SSE 제외)
  - `AlanViewModel.swift`

## 링크
- [노션 태스크](https://www.notion.so/oreumi/Alan-API-245ebaa8982b80caa8d1cd77a460848e?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)
- [xcconfig](https://www.notion.so/oreumi/xcconfig-241ebaa8982b80149419dd8ba6a7186e?source=copy_link)