### PR TITLE
feat: 캘린더 탭 연월 타이틀 및 요일 행 추가

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -9,27 +9,30 @@ final class CalendarViewController: CoreViewController {
         collectionView.dataSource = self
         collectionView.delegate = self
         collectionView.collectionViewLayout = createCompositionalLayout()
-        collectionView.register(CalendarMonthCell.self, forCellWithReuseIdentifier: CalendarMonthCell.id)
-        collectionView.backgroundColor = .systemBackground
+        collectionView.register(
+            UINib(nibName: "CalendarMonthCell", bundle: nil),
+            forCellWithReuseIdentifier: CalendarMonthCell.id
+        )
     }
 
     private func createCompositionalLayout() -> UICollectionViewLayout {
         UICollectionViewCompositionalLayout { sectionIndex, environment in
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(44)
+                heightDimension: .estimated(300)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-            let groupSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(300)
-            )
+            let groupSize = itemSize
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 
             let section = NSCollectionLayoutSection(group: group)
-            section.interGroupSpacing = 16
-            section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: UICollectionViewConstant.defaultInset,
+                leading: UICollectionViewConstant.defaultInset,
+                bottom: UICollectionViewConstant.defaultInset,
+                trailing: UICollectionViewConstant.defaultInset
+            )
             return section
         }
     }
@@ -48,7 +51,12 @@ extension CalendarViewController: UICollectionViewDataSource, UICollectionViewDe
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarMonthCell.id, for: indexPath) as? CalendarMonthCell else {
             fatalError("Failed to dequeue CalendarMonthCell")
         }
-        // TODO: month 데이터 주입 예정
+
+        let today = Date()
+        let currentYear = today.year
+        let currentMonth = indexPath.section + 1
+        cell.configure(year: currentYear, month: currentMonth)
+
         return cell
     }
 }

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -10,7 +10,7 @@ final class CalendarViewController: CoreViewController {
         collectionView.delegate = self
         collectionView.collectionViewLayout = createCompositionalLayout()
         collectionView.register(
-            UINib(nibName: "CalendarMonthCell", bundle: nil),
+            CalendarMonthCell.nib,
             forCellWithReuseIdentifier: CalendarMonthCell.id
         )
     }

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -1,5 +1,9 @@
 import UIKit
 
 final class CalendarMonthCell: CoreCollectionViewCell {
-    
+    @IBOutlet weak var yearMonthLabel: UILabel!
+
+    func configure(year: Int, month: Int) {
+        yearMonthLabel.text = "\(year)년 \(month)월"
+    }
 }

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.xib
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.xib
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="CalendarMonthCell" customModule="Health" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="332" height="118"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="332" height="118"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2025년 7월" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oh1-q2-x3o">
+                        <rect key="frame" x="0.0" y="0.0" width="332" height="26.333333333333332"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="a17-6b-e69">
+                        <rect key="frame" x="0.0" y="42.333333333333336" width="332" height="20"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxN-sS-2lS" userLabel="일">
+                                <rect key="frame" x="0.0" y="0.0" width="47.333333333333336" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pbV-S3-DMw" userLabel="하지만">
+                                <rect key="frame" x="47.333333333333343" y="0.0" width="47.666666666666657" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="화" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ibh-Fd-fUs" userLabel="일">
+                                <rect key="frame" x="95" y="0.0" width="47.333333333333343" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Q6-C5-EEj" userLabel="일">
+                                <rect key="frame" x="142.33333333333334" y="0.0" width="47.333333333333343" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="37k-S6-cci" userLabel="일">
+                                <rect key="frame" x="189.66666666666666" y="0.0" width="47.333333333333343" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="금" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rPB-7T-j6y" userLabel="일">
+                                <rect key="frame" x="236.99999999999997" y="0.0" width="47.666666666666657" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="토" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q6T-mA-rIj" userLabel="일">
+                                <rect key="frame" x="284.66666666666669" y="0.0" width="47.333333333333314" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="4j6-48-ifG"/>
+                        </constraints>
+                    </stackView>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="a17-6b-e69" secondAttribute="trailing" id="2cM-uW-Nma"/>
+                <constraint firstItem="a17-6b-e69" firstAttribute="top" secondItem="oh1-q2-x3o" secondAttribute="bottom" constant="16" id="Ekw-jo-Rm2"/>
+                <constraint firstItem="a17-6b-e69" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="bcK-de-cmm"/>
+                <constraint firstItem="oh1-q2-x3o" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="i9E-p3-V0b"/>
+                <constraint firstItem="oh1-q2-x3o" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="nub-7X-Qw1"/>
+                <constraint firstAttribute="trailing" secondItem="oh1-q2-x3o" secondAttribute="trailing" id="pQD-bf-uSH"/>
+            </constraints>
+            <size key="customSize" width="332" height="118"/>
+            <connections>
+                <outlet property="yearMonthLabel" destination="oh1-q2-x3o" id="bHa-jM-Pom"/>
+            </connections>
+            <point key="canvasLocation" x="229.00763358778624" y="65.492957746478879"/>
+        </collectionViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
## 작업 내용
- 캘린더 탭 월별 달력에 연월 타이틀 추가
- 요일 행 (일요일부터 토요일까지) 추가

| CalendarMonthCell 스토리보드 | 시뮬레이터 |
| -- | -- |
| <img width="540" height="245" alt="image" src="https://github.com/user-attachments/assets/d5ec6e9a-b4cf-4f60-bd05-d0c004ae2d3f" /> | <img width="603" height="1311" alt="simulator_screenshot_7A23CCDC-F568-469B-A62D-EB6815C670F7" src="https://github.com/user-attachments/assets/ad3f0874-d2ba-42e1-8f24-86aa3fbe8917" /> |

## 링크
- [노션 태스크](https://www.notion.so/oreumi/245ebaa8982b802a9268dc6bfde69a97?source=copy_link)