### PR TITLE
fix: 캘린더 탭 패드 가로/세로 대응

### DIFF
--- a/Health/DesignSystem/Constant/UIView+CornerRadius.swift
+++ b/Health/DesignSystem/Constant/UIView+CornerRadius.swift
@@ -32,24 +32,33 @@ extension UIView {
         case custom(CGFloat) // 커스텀 값
     }
 
-    /// 코너 스타일을 쉽게 적용하는 메서드
+    /// UIView의 모서리를 다양한 스타일로 설정합니다.
+    ///
+    /// - Note: `.circular` 스타일은 뷰가 정사각형일 경우에만 완전한 원이 됩니다.
+    ///         이 스타일은 뷰의 레이아웃이 확정된 이후(`layoutIfNeeded()` 호출 후)에 적용해야 정확합니다.
     func applyCornerStyle(_ style: CornerStyle) {
         switch style {
-        case .small:
-            layer.cornerRadius = CornerRadius.small
-        case .medium:
-            layer.cornerRadius = CornerRadius.medium
-        case .large:
-            layer.cornerRadius = CornerRadius.large
-        case .circular:
-            // 원형으로 만들기 (정사각형일 때만 완전한 원)
-            layer.cornerRadius = min(frame.width, frame.height) / 2
-        case .custom(let radius):
-            layer.cornerRadius = radius
+            case .small:
+                layer.cornerRadius = CornerRadius.small
+
+            case .medium:
+                layer.cornerRadius = CornerRadius.medium
+
+            case .large:
+                layer.cornerRadius = CornerRadius.large
+
+            case .circular:
+                // 레이아웃이 아직 반영되지 않았을 수 있으므로 먼저 강제 layout 수행
+                layoutIfNeeded()
+                layer.cornerRadius = min(bounds.width, bounds.height) / 2
+
+            case .custom(let radius):
+                layer.cornerRadius = radius
         }
 
-        // 코너 반지름 적용시 기본 설정
+        // cornerRadius 적용 시 마스킹도 반드시 켜줘야 실제로 적용됨
         layer.masksToBounds = true
+        clipsToBounds = true
     }
 }
 // MARK: - 사용법 요약 주석

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -29,8 +29,9 @@ final class CalendarViewController: CoreGradientViewController {
     private func createLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            // TODO: 실제 컨텐츠 높이에 따라 유동적으로 설정
-            heightDimension: .fractionalWidth(1.0)
+            heightDimension: .estimated(300)
+            // 실제 높이는 CalendarMonthCell 내 dateCollectionView의 콘텐츠 크기에 따라 유동적으로 결정됩니다.
+            // estimated 값은 초기 레이아웃 계산 시의 기준 높이일 뿐이며, 오토레이아웃에 의해 확장됩니다.
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -30,7 +30,7 @@ final class CalendarViewController: CoreGradientViewController {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             // TODO: 실제 컨텐츠 높이에 따라 유동적으로 설정
-            heightDimension: .estimated(400)
+            heightDimension: .fractionalWidth(1.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 

--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -5,20 +5,25 @@ final class CalendarDateCell: CoreCollectionViewCell {
     @IBOutlet weak var circleView: UIView!
     @IBOutlet weak var dateLabel: UILabel!
 
+    @IBOutlet weak var circleViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var circleViewBottomConstraint: NSLayoutConstraint!
+    @IBOutlet weak var circleViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var circleViewTrailingConstraint: NSLayoutConstraint!
+
     private let progressBar = CalendarProgressBar()
+
+    private var previousInset: CGFloat?
 
     override func setupHierarchy() {
         super.setupHierarchy()
         circleView.addSubview(progressBar)
     }
 
-    override func setupAttribute() {
-        super.setupAttribute()
-        progressBar.translatesAutoresizingMaskIntoConstraints = false
-    }
-
     override func setupConstraints() {
         super.setupConstraints()
+
+        progressBar.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
             progressBar.centerXAnchor.constraint(equalTo: circleView.centerXAnchor),
             progressBar.centerYAnchor.constraint(equalTo: circleView.centerYAnchor),
@@ -29,6 +34,20 @@ final class CalendarDateCell: CoreCollectionViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        let insetRatio: CGFloat = 0.1
+        let inset = bounds.width * insetRatio
+
+        // 불필요한 layout 반복 방지
+        if previousInset != inset {
+            circleViewTopConstraint.constant = inset
+            circleViewBottomConstraint.constant = inset
+            circleViewLeadingConstraint.constant = inset
+            circleViewTrailingConstraint.constant = inset
+
+            previousInset = inset
+        }
+
         circleView.applyCornerStyle(.circular) // 가로/세로 전환시
     }
 

--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -14,7 +14,6 @@ final class CalendarDateCell: CoreCollectionViewCell {
 
     override func setupAttribute() {
         super.setupAttribute()
-        circleView.applyCornerStyle(.circular)
         progressBar.translatesAutoresizingMaskIntoConstraints = false
     }
 
@@ -28,6 +27,11 @@ final class CalendarDateCell: CoreCollectionViewCell {
         ])
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        circleView.applyCornerStyle(.circular) // 가로/세로 전환시
+    }
+
     func configure(date: Date, currentSteps: Int, goalSteps: Int) {
         // 달력상 빈 날짜일 때
         if date == .distantPast {
@@ -35,8 +39,9 @@ final class CalendarDateCell: CoreCollectionViewCell {
             return
         }
 
-        progressBar.progress = CGFloat(currentSteps) / CGFloat(goalSteps)
+        circleView.applyCornerStyle(.circular) // 초기 진입시
         dateLabel.text = "\(date.day)"
+        progressBar.progress = CGFloat(currentSteps) / CGFloat(goalSteps)
         progressBar.isHidden = false
 
         let isCompleted = currentSteps >= goalSteps

--- a/Health/Presentation/Calendar/Views/CalendarDateCell.xib
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.xib
@@ -16,7 +16,7 @@
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zgw-pB-d4u">
-                        <rect key="frame" x="5" y="5" width="40" height="40"/>
+                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                         <color key="backgroundColor" red="0.41568627450980389" green="0.41568627450980389" blue="0.41568627450980389" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HvE-6x-7zc">
@@ -30,13 +30,17 @@
             <constraints>
                 <constraint firstItem="HvE-6x-7zc" firstAttribute="centerX" secondItem="Zgw-pB-d4u" secondAttribute="centerX" id="3fc-9L-oHb"/>
                 <constraint firstItem="HvE-6x-7zc" firstAttribute="centerY" secondItem="Zgw-pB-d4u" secondAttribute="centerY" id="5gN-JV-YgV"/>
-                <constraint firstItem="Zgw-pB-d4u" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="5" id="APa-th-hsN"/>
-                <constraint firstAttribute="bottom" secondItem="Zgw-pB-d4u" secondAttribute="bottom" constant="5" id="ORs-5K-gHL"/>
-                <constraint firstAttribute="trailing" secondItem="Zgw-pB-d4u" secondAttribute="trailing" constant="5" id="OSi-aT-9gY"/>
-                <constraint firstItem="Zgw-pB-d4u" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="5" id="ThV-xE-G1S"/>
+                <constraint firstAttribute="bottom" secondItem="Zgw-pB-d4u" secondAttribute="bottom" id="6lZ-hQ-kaY"/>
+                <constraint firstItem="Zgw-pB-d4u" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="QXN-hr-0Hh"/>
+                <constraint firstItem="Zgw-pB-d4u" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="khX-hY-koP"/>
+                <constraint firstAttribute="trailing" secondItem="Zgw-pB-d4u" secondAttribute="trailing" id="oY0-eu-aRM"/>
             </constraints>
             <connections>
                 <outlet property="circleView" destination="Zgw-pB-d4u" id="SFc-tx-7hB"/>
+                <outlet property="circleViewBottomConstraint" destination="6lZ-hQ-kaY" id="fUP-OZ-6gh"/>
+                <outlet property="circleViewLeadingConstraint" destination="khX-hY-koP" id="a8O-Se-8hT"/>
+                <outlet property="circleViewTopConstraint" destination="QXN-hr-0Hh" id="LhE-my-rT9"/>
+                <outlet property="circleViewTrailingConstraint" destination="oY0-eu-aRM" id="vpA-3w-BTF"/>
                 <outlet property="dateLabel" destination="HvE-6x-7zc" id="cqR-DE-te9"/>
             </connections>
             <point key="canvasLocation" x="138.93129770992365" y="41.549295774647888"/>

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -39,11 +39,6 @@ final class CalendarMonthCell: CoreCollectionViewCell {
         return UICollectionViewCompositionalLayout(section: section)
     }
 
-    func getNumberOfRows() -> Int {
-        let numberOfItems = datesWithBlank.count
-        return Int(ceil(Double(numberOfItems) / 7.0))
-    }
-
     func configure(year: Int, month: Int) {
         let calendar = Calendar.gregorian
         guard let firstDay = DateComponents(calendar: calendar, year: year, month: month).date else {

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -4,7 +4,8 @@ final class CalendarMonthCell: CoreCollectionViewCell {
 
     @IBOutlet weak var yearMonthLabel: UILabel!
     @IBOutlet weak var dateCollectionView: UICollectionView!
-
+    @IBOutlet weak var dateCollectionViewHeightConstraint: NSLayoutConstraint!
+    
     private var datesWithBlank: [Date] = []
 
     override func setupAttribute() {
@@ -38,6 +39,11 @@ final class CalendarMonthCell: CoreCollectionViewCell {
         return UICollectionViewCompositionalLayout(section: section)
     }
 
+    func getNumberOfRows() -> Int {
+        let numberOfItems = datesWithBlank.count
+        return Int(ceil(Double(numberOfItems) / 7.0))
+    }
+
     func configure(year: Int, month: Int) {
         let calendar = Calendar.gregorian
         guard let firstDay = DateComponents(calendar: calendar, year: year, month: month).date else {
@@ -46,15 +52,16 @@ final class CalendarMonthCell: CoreCollectionViewCell {
 
         yearMonthLabel.text = firstDay.formatted(using: "yyyy년 M월")
 
-        // 해당 월의 모든 날짜
+		// 1일 앞의 빈칸을 포함한 모든 날짜
         let dates = firstDay.datesInMonth(using: calendar)
-
-        // 첫 번째 날의 요일
-        // 일요일 = 1, 월요일 = 2, ...
         let weekday = calendar.component(.weekday, from: firstDay)
-
-        // 빈칸 포함 모든 날짜
         datesWithBlank = Array(repeating: Date.distantPast, count: weekday - 1) + dates
+
+        // 셀 크기 동적 조정을 위한 dateCollectionView 높이 계산
+        let totalItems = datesWithBlank.count
+        let numberOfRows = Int(ceil(Double(totalItems) / 7.0))
+        let itemWidth = UIScreen.main.bounds.width / 7
+        dateCollectionViewHeightConstraint.constant = CGFloat(numberOfRows) * itemWidth
 
         dateCollectionView.reloadData()
     }

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -27,7 +27,7 @@ final class CalendarMonthCell: CoreCollectionViewCell {
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(100)
+            heightDimension: .fractionalWidth(1.0 / 7.0)
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.xib
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.xib
@@ -74,6 +74,9 @@
                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Ejp-Gl-eHb">
                         <rect key="frame" x="0.0" y="78.333333333333314" width="332" height="120.66666666666669"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="120.66666666666669" id="HUG-mc-1jW"/>
+                        </constraints>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="cGp-tr-K6c">
                             <size key="itemSize" width="128" height="128"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -98,6 +101,7 @@
             <size key="customSize" width="332" height="199"/>
             <connections>
                 <outlet property="dateCollectionView" destination="Ejp-Gl-eHb" id="tR9-MO-CbJ"/>
+                <outlet property="dateCollectionViewHeightConstraint" destination="HUG-mc-1jW" id="tqP-KM-8JD"/>
                 <outlet property="yearMonthLabel" destination="oh1-q2-x3o" id="bHa-jM-Pom"/>
             </connections>
             <point key="canvasLocation" x="229.00763358778624" y="94.014084507042256"/>

--- a/Health/Presentation/Calendar/Views/CalendarProgressBar.swift
+++ b/Health/Presentation/Calendar/Views/CalendarProgressBar.swift
@@ -29,10 +29,12 @@ final class CalendarProgressBar: CoreView {
         super.layoutSubviews()
         progressLayer.frame = bounds
 
-        let lineWidth: CGFloat = 5
+        let lineWidth = bounds.width * 0.08
+        let radius = (min(bounds.width, bounds.height) - lineWidth) / 2
+
         let path = UIBezierPath(
             arcCenter: CGPoint(x: bounds.midX, y: bounds.midY),
-            radius: (min(bounds.width, bounds.height) - lineWidth) / 2,
+            radius: radius,
             startAngle: -.pi / 2,
             endAngle: 1.5 * .pi,
             clockwise: true


### PR DESCRIPTION
## 작업내용
아이폰/아이패드에서 캘린더 탭 진입시 혹은 가로/세로 변경시
- 각 날짜의 원형배경 (CircleView) 제대로 표시
- 달력 아래부분이 짤리지 않도록 높이 조정
- 각 날짜 사이 간격 조정
- 월별 셀 높이 동적 조정
> 폰트 크기는 추후 논의 후 적용

## 테스트

### iPhone 세로
| Before | After |
| -- | -- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/51eaba94-cd3e-4f8f-abd6-b4ac58b09a6e" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f617a294-b412-4b0e-95f4-451e7d1a768e" /> |

### iPad 세로
| Before | After |
| -- | -- |
| <img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/2c82c758-baef-476c-bd38-af39de245b5a" /> | <img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/a3602446-37f2-4aae-8acc-3f8b97f7407c" /> |

### iPad 가로
| Before | After |
| -- | -- |
| <img width="2048" height="1423" alt="image" src="https://github.com/user-attachments/assets/b8e1361d-d1f6-4b0b-88e4-2e46da8ab95c" /> | <img width="2048" height="1423" alt="image" src="https://github.com/user-attachments/assets/95a9977e-dc65-4a9c-8646-c7a97e5754a2" /> |

## 링크
- [노션 태스크](https://www.notion.so/oreumi/246ebaa8982b8047bd1df491354073b6?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)