### PR TITLE
feat: info.plist에 Client ID 키 추가, 빌드 스킴에 따라 xcconfig를 받도록 수정, xcconfig에 따라 서로 다른 번들 ID로 세팅되도록 빌드 설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,6 @@ xcuserdata/
 *.xccheckout
 *.xcconfig
 
-# API Keys 
-Secrets.xcconfig
-Resources/Secrets.xcconfig
-
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
 DerivedData/

--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C7178BA82E448029004A87B2 /* app-release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = C7178BA72E448029004A87B2 /* app-release.xcconfig */; };
+		C7178BA92E448029004A87B2 /* app-debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = C7178BA62E448029004A87B2 /* app-debug.xcconfig */; };
 		C76CA76E2E3AE2110040EF75 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = C76CA76D2E3AE2110040EF75 /* FirebaseAnalyticsCore */; };
 		C76CA80E2E3B2D1A0040EF75 /* TSAlertController in Frameworks */ = {isa = PBXBuildFile; productRef = C76CA80D2E3B2D1A0040EF75 /* TSAlertController */; };
 /* End PBXBuildFile section */
@@ -22,6 +24,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C7178BA62E448029004A87B2 /* app-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "app-debug.xcconfig"; sourceTree = "<group>"; };
+		C7178BA72E448029004A87B2 /* app-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "app-release.xcconfig"; sourceTree = "<group>"; };
 		C76490972E3790170062054D /* Health.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Health.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C76490C32E3790410062054D /* HealthTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HealthTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -79,6 +83,8 @@
 				C76490C42E3790410062054D /* HealthTests */,
 				C76CA76C2E3AE2110040EF75 /* Frameworks */,
 				C76490982E3790170062054D /* Products */,
+				C7178BA62E448029004A87B2 /* app-debug.xcconfig */,
+				C7178BA72E448029004A87B2 /* app-release.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -197,6 +203,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C7178BA82E448029004A87B2 /* app-release.xcconfig in Resources */,
+				C7178BA92E448029004A87B2 /* app-debug.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,6 +245,7 @@
 /* Begin XCBuildConfiguration section */
 		C76490AB2E3790180062054D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C7178BA62E448029004A87B2 /* app-debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -259,7 +268,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.est-3rd.walking";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -274,6 +283,7 @@
 		};
 		C76490AC2E3790180062054D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C7178BA72E448029004A87B2 /* app-release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -296,7 +306,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.est-3rd.walking";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Health/Application/AppDelegate.swift
+++ b/Health/Application/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         DIContainer.shared.registerHealthService()
         DIContainer.shared.registerNetworkService()
-
+        print(AppConfiguration.clientID)
         return true
     }
 

--- a/Health/Application/Configuration/AppConfiguration.swift
+++ b/Health/Application/Configuration/AppConfiguration.swift
@@ -37,6 +37,6 @@ struct AppConfiguration {
     ///
     /// - **Important**: Info.plist에 `CURRENT_CLIENT_ID` 키가 올바르게 설정되어 있는지 확인하세요.
     static var clientID: String {
-        Bundle.main.infoDictionary?["CURRENT_CLIENT_ID"] as? String ?? "unknown"
+        Bundle.main.object(forInfoDictionaryKey: "Client ID") as? String ?? "unknown"
     }
 }

--- a/Health/Resources/Info.plist
+++ b/Health/Resources/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AlanCurrentClientID</key>
-	<string>$(CURRENT_CLIENT_ID)</string>
+	<key>Client ID</key>
+	<string>$(CLIENT_ID)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
----
**주의⚠️:** 해당 PR이 병합된 후, 반드시 프로젝트의 최상위 디렉토리에 
`app-debug.xconfig`와 `app-release.xcconfig` 파일을 추가하셔야 빌드가 제대로 됩니다. 

(.xcconfig 파일은 gitignore되어 있습니다.)

 ----

## ✅ 변경사항

- `.xcconfig` 파일로부터 `Client_id` 값을 제대로 불러오지 못하는 문제 수정

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="355" height="101" alt="스크린샷 2025-08-07 오후 3 49 22" src="https://github.com/user-attachments/assets/60601fe7-bf38-478a-aa65-e4d0aa627ced" /> |     |

---

### 💜 참고 1️⃣

- .xcconfig 파일은 오늘자 회의록에 첨부해두었습니다. 자신 클라이언트 키로 수정 후, 사용하세요~


### ⭐️ 참고 2️⃣

- **중요⭐️:** 각 `xcconfig` 파일에 번들 ID를 입력받을 수 있는 입력란이 있습니다. 각자 개발 환경에서 번들 ID를 수정하셔서 **본인의 번들 ID를 사용**해주세요. HealthKit Entitlements 문제도 사라지리라 생각됩니다.
