### PR TITLE
feat: 앱 실행시 걸음 데이터 동기화 로직 추가

### DIFF
--- a/Health/Application/AppDelegate.swift
+++ b/Health/Application/AppDelegate.swift
@@ -24,15 +24,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		Task {
 			await NetworkMonitor.shared.startMonitoring()
 		}
+
         // TODO: - 앱 성능 테스트 관련 작업 시작할 때 주석 해제하기
 		//FirebaseApp.configure()
 
-        DIContainer.shared.registerHealthService()
-        DIContainer.shared.registerNetworkService()
-
+        DIContainer.shared.registerAllServices()
+        
         CoreDataStack.shared.insertDummyData()
-        
-        
+
         /* dummydata test code
          
         let context = CoreDataStack.shared.viewContext

--- a/Health/Application/SceneDelegate.swift
+++ b/Health/Application/SceneDelegate.swift
@@ -11,6 +11,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
+    @Injected var stepSyncViewModel: StepSyncViewModel
 
     func scene(
         _ scene: UIScene,
@@ -24,6 +25,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+#if DEBUG
+        print("앱 활성화됨 → 걸음 데이터 동기화")
+#endif
+        Task {
+            await stepSyncViewModel.syncDailySteps()
+        }
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -34,7 +41,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {
     }
-
-
 }
 

--- a/Health/Core/DIContainer/DIContainer+Register.swift
+++ b/Health/Core/DIContainer/DIContainer+Register.swift
@@ -21,7 +21,7 @@ extension DIContainer {
     /// 건강 데이터 조회 서비스를 의존성 주입 컨테이너에 등록합니다.
     ///
     /// 이 메서드는 빌드 구성에 따라 적절한 HealthKit 서비스 구현체를 등록합니다:
-    /// - **DEBUG**: `MockhealthService`를 등록하여 테스트 및 개발 환경에서 사용
+    /// - **DEBUG**: `MockHealthService`를 등록하여 테스트 및 개발 환경에서 사용
     /// - **RELEASE**: `DefaultHealthService`를 등록하여 프로덕션 환경에서 사용
     func registerHealthService() {
         self.register(.healthService) { _ in
@@ -31,5 +31,34 @@ extension DIContainer {
             return DefaultHealthService()
 #endif
         }
+    }
+
+    func registerDailyStepViewModel() {
+        self.register(type: DailyStepViewModel.self) { _ in
+            DailyStepViewModel(context: CoreDataStack.shared.viewContext)
+        }
+    }
+
+    func registerGoalStepCountViewModel() {
+        self.register(type: GoalStepCountViewModel.self) { _ in
+            GoalStepCountViewModel(context: CoreDataStack.shared.viewContext)
+        }
+    }
+
+    /// 걸음 수 동기화를 담당하는 ViewModel을 의존성 주입 컨테이너에 등록합니다.
+    ///
+    /// 내부적으로 `@Injected`를 사용하는 의존성(`HealthService`, `DailyStepViewModel`, `GoalStepCountViewModel`)이 먼저 등록되어 있어야 합니다.
+    func registerStepSyncViewModel() {
+        self.register(type: StepSyncViewModel.self, name: nil) { _ in
+            StepSyncViewModel()
+        }
+    }
+
+    func registerAllServices() {
+        registerNetworkService()
+        registerHealthService()
+        registerDailyStepViewModel()
+        registerGoalStepCountViewModel()
+        registerStepSyncViewModel()
     }
 }

--- a/Health/Core/DIContainer/InjectIdentifier+Keys.swift
+++ b/Health/Core/DIContainer/InjectIdentifier+Keys.swift
@@ -34,4 +34,38 @@ extension InjectIdentifier {
     static var healthService: InjectIdentifier<HealthService> {
         InjectIdentifier<HealthService>(type: HealthService.self)
     }
+
+    /// 일일 걸음 수 관리 ViewModel을 식별하는 정적 속성
+    ///
+    /// `DailyStepViewModel` 클래스를 의존성 주입 컨테이너에서
+    /// 등록하고 해결할 때 사용되는 타입 안전한 식별자입니다.
+    ///
+    /// - Returns: `DailyStepViewModel` 타입의 `InjectIdentifier` 인스턴스
+    /// - Note: Core Data의 `viewContext`와 함께 초기화됩니다.
+    static var dailyStepViewModel: InjectIdentifier<DailyStepViewModel> {
+        InjectIdentifier<DailyStepViewModel>(type: DailyStepViewModel.self)
+    }
+
+    /// 목표 걸음 수 설정 ViewModel을 식별하는 정적 속성
+    ///
+    /// `GoalStepCountViewModel` 클래스를 의존성 주입 컨테이너에서
+    /// 등록하고 해결할 때 사용되는 타입 안전한 식별자입니다.
+    ///
+    /// - Returns: `GoalStepCountViewModel` 타입의 `InjectIdentifier` 인스턴스
+    /// - Note: Core Data의 `viewContext`와 함께 초기화됩니다.
+    static var goalStepCountViewModel: InjectIdentifier<GoalStepCountViewModel> {
+        InjectIdentifier<GoalStepCountViewModel>(type: GoalStepCountViewModel.self)
+    }
+
+    /// 걸음 수 동기화 ViewModel을 식별하는 정적 속성
+    ///
+    /// `StepSyncViewModel` 클래스를 의존성 주입 컨테이너에서
+    /// 등록하고 해결할 때 사용되는 타입 안전한 식별자입니다.
+    ///
+    /// - Returns: `StepSyncViewModel` 타입의 `InjectIdentifier` 인스턴스
+    /// - Important: 이 ViewModel은 `@Injected` 프로퍼티를 통해 다른 서비스들에 의존하므로,
+    ///   해당 서비스들이 먼저 등록되어 있어야 합니다.
+    static var stepSyncViewModel: InjectIdentifier<StepSyncViewModel> {
+        InjectIdentifier<StepSyncViewModel>(type: StepSyncViewModel.self)
+    }
 }

--- a/Health/ViewModels/EntityViewModels/DailyStepViewModel.swift
+++ b/Health/ViewModels/EntityViewModels/DailyStepViewModel.swift
@@ -53,6 +53,8 @@ final class DailyStepViewModel: ObservableObject {
         stepCount: Int32,
         goalStepCount: Int32
     ) {
+        let normalizedDate = date.startOfDay()
+
         let entity: DailyStepEntity
         if let id = id, let existing = fetchDailyStep(by: id) {
             entity = existing
@@ -61,7 +63,7 @@ final class DailyStepViewModel: ObservableObject {
             entity.id = UUID()
         }
 
-        entity.date = date
+        entity.date = normalizedDate
         entity.stepCount = stepCount
         entity.goalStepCount = goalStepCount
 
@@ -84,8 +86,10 @@ final class DailyStepViewModel: ObservableObject {
         stepCount: Int32,
         goalStepCount: Int32
     ) {
+        let normalizedDate = date.startOfDay()
+
         let request: NSFetchRequest<DailyStepEntity> = DailyStepEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "date == %@", date as CVarArg)
+        request.predicate = NSPredicate(format: "date == %@", normalizedDate as CVarArg)
         request.fetchLimit = 1
 
         do {
@@ -94,7 +98,7 @@ final class DailyStepViewModel: ObservableObject {
 
             if existing == nil {
                 entity.id = UUID()
-                entity.date = date
+                entity.date = normalizedDate
             }
 
             entity.stepCount = stepCount
@@ -112,13 +116,14 @@ final class DailyStepViewModel: ObservableObject {
     /// - Parameter today: 오늘 날짜 (00:00으로 정규화된 값 권장)
     /// - Returns: 누락된 날짜 배열 (오름차순)
     func fetchMissingDates(until today: Date) -> [Date] {
+        let normalizedToday = today.startOfDay()
         let savedDates = dailySteps.compactMap { $0.date?.startOfDay() }
         let lastSavedDate = savedDates.max() ?? Calendar.current.date(byAdding: .day, value: -7, to: today)!
 
         var dates: [Date] = []
         var current = Calendar.current.date(byAdding: .day, value: 1, to: lastSavedDate)!
 
-        while current <= today {
+        while current <= normalizedToday {
             dates.append(current)
             current = Calendar.current.date(byAdding: .day, value: 1, to: current)!
         }

--- a/Health/ViewModels/EntityViewModels/GoalStepCountViewModel.swift
+++ b/Health/ViewModels/EntityViewModels/GoalStepCountViewModel.swift
@@ -57,7 +57,7 @@ final class GoalStepCountViewModel: ObservableObject {
         let normalizedDate = date.startOfDay()
 
         let request: NSFetchRequest<GoalStepCountEntity> = GoalStepCountEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "effectiveDate <= %@", date as CVarArg)
+        request.predicate = NSPredicate(format: "effectiveDate <= %@", normalizedDate as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \GoalStepCountEntity.effectiveDate, ascending: false)]
         request.fetchLimit = 1
 

--- a/Health/ViewModels/EntityViewModels/GoalStepCountViewModel.swift
+++ b/Health/ViewModels/EntityViewModels/GoalStepCountViewModel.swift
@@ -54,6 +54,8 @@ final class GoalStepCountViewModel: ObservableObject {
     /// - Parameter date: 찾고자 하는 날짜
     /// - Returns: 해당 날짜에 유효한 목표 걸음 수 또는 nil
     func goalStepCount(for date: Date) -> Int32? {
+        let normalizedDate = date.startOfDay()
+
         let request: NSFetchRequest<GoalStepCountEntity> = GoalStepCountEntity.fetchRequest()
         request.predicate = NSPredicate(format: "effectiveDate <= %@", date as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \GoalStepCountEntity.effectiveDate, ascending: false)]
@@ -73,6 +75,8 @@ final class GoalStepCountViewModel: ObservableObject {
         goalStepCount: Int32,
         effectiveDate: Date
     ) {
+        let normalizedEffectiveDate = effectiveDate.startOfDay()
+
         let entity: GoalStepCountEntity
         if let id = id, let existing = fetchGoalStepCount(by: id) {
             entity = existing
@@ -82,7 +86,7 @@ final class GoalStepCountViewModel: ObservableObject {
         }
 
         entity.goalStepCount = goalStepCount
-        entity.effectiveDate = effectiveDate
+        entity.effectiveDate = normalizedEffectiveDate
 
         do {
             try context.save()

--- a/Health/ViewModels/StepSyncViewModel.swift
+++ b/Health/ViewModels/StepSyncViewModel.swift
@@ -1,0 +1,88 @@
+import HealthKit
+
+/// `StepSyncViewModel`은 HealthKit 데이터를 기반으로 누락된 일자들의 걸음 수를 CoreData에 반영하는 역할을 담당합니다.
+///
+/// 앱이 실행되거나 포그라운드로 전환될 때 `DailyStepEntity`에 저장되지 않은 날짜들을 찾아
+/// HealthKit에서 걸음 수를 가져와 저장합니다. 의존성 주입을 통해 필요한 서비스들을 사용합니다.
+///
+/// - Note: HealthKit 권한이 필요하며, 권한이 없을 경우 동기화가 실패할 수 있습니다.
+@MainActor
+final class StepSyncViewModel: ObservableObject {
+
+    @Injected private var healthService: HealthService
+    @Injected private var dailyStepVM: DailyStepViewModel
+    @Injected private var goalStepCountVM: GoalStepCountViewModel
+
+    @Published var syncCompleted: Bool = false
+    @Published var errorMessage: String?
+
+    func syncDailySteps() async {
+        let today = Date().startOfDay()
+        let missingDates = dailyStepVM.fetchMissingDates(until: today)
+
+        guard !missingDates.isEmpty else {
+            syncCompleted = true
+            return
+        }
+
+        var successCount = 0
+        var failureCount = 0
+        var errors: [String] = []
+
+        await withTaskGroup(of: Bool.self) { group in
+            for date in missingDates {
+                group.addTask { @Sendable in
+                    do {
+                        try await self.syncStep(for: date)
+                        return true
+                    } catch {
+                        await MainActor.run {
+                            errors.append("\(date.formatted(using: .m_d)): \(error.localizedDescription)")
+                        }
+                        return false
+                    }
+                }
+            }
+
+            for await result in group {
+                if result {
+                    successCount += 1
+                } else {
+                    failureCount += 1
+                }
+            }
+        }
+
+        syncCompleted = true
+        errorMessage = errors.isEmpty ? nil : errors.joined(separator: "\n")
+
+#if DEBUG
+        print("[동기화 완료] 성공: \(successCount)개, 실패: \(failureCount)개")
+        errors.forEach { print($0) }
+#endif
+    }
+
+    private func syncStep(for date: Date) async throws {
+        let normalizedDate = date.startOfDay()
+        let endDate = normalizedDate.endOfDay()
+
+        let result = try await healthService.fetchStatistics(
+            for: .stepCount,
+            from: normalizedDate,
+            to: endDate,
+            options: .cumulativeSum,
+            unit: .count()
+        )
+
+        let stepCount = Int32(result.value.rounded())
+        let goal = goalStepCountVM.goalStepCount(for: normalizedDate) ?? 10_000
+
+        await MainActor.run {
+            dailyStepVM.upsertDailyStep(for: normalizedDate, stepCount: stepCount, goalStepCount: goal)
+
+#if DEBUG
+            print("[동기화] \(normalizedDate.formatted(using: .m_d)) | 걸음 수: \(stepCount) | 목표: \(goal)")
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## 작업내용
- 앱이 포그라운드 상태가 될 때마다 걸음 데이터를 동기화하는 로직을 추가했습니다.
- 동기화 로직에서는 2가지 작업을 진행합니다.
    - 이전 날짜에 기록이 없으면 채우기
    - 현재 걸음수 업데이트하기

### 추후 작업
- 온보딩 후 동기화

### 유저 시나리오
날짜 | 사용자의 행동 | GoalStepCount 엔티티 상태 | 생성된 DailyStep 및 스냅샷
-- | -- | -- | --
8/1 | 앱 최초 실행 (온보딩) → 목표 10,000보 설정 | ✅ GoalStepCount(effectiveDate: 8/1, goalStepCount: 10000) | ✅ DailyStep(date: 8/1, stepCount: 0, goalStepSnapshot: 10000) (stepCount의 초기값은 HealthKit으로 덮어써야 함)
| <strong>8/2</strong> | 앱 미접속 | 변경 없음 | ❌ 없음
| <strong>8/3</strong> | 앱 진입 → HealthKit로 8/3 걸음 수 8,000보 확인 | 변경 없음 | ✅ 8/2: <code>DailyStep(stepCount: 4000, goalStepSnapshot: 10000)</code></br>✅ 8/3: <code>DailyStep(stepCount: 8000, goalStepSnapshot: 10000)</code> |  
<strong>8/4~8/9</strong> | 앱 미접속 | 변경 없음 | ❌ 없음 |
| <strong>8/10</strong> | 앱 진입 → 목표를 5,000보로 변경 | ✅ <code>GoalStepCount(effectiveDate: 8/10, goalStepCount: 5000)</code> | ✅ 8/4~8/9: <code>DailyStep(stepCount: 2000, goalStepSnapshot: 10000)</code></br >✅ 8/10: <code>DailyStep(stepCount: 0, goalStepSnapshot: 5000)</code>
| <strong>8/11</strong> | 앱 미접속 | 변경 없음 | ❌ 없음
| <strong>8/12</strong> | 앱 진입 | 변경 없음 | ✅ 8/11, 8/12: <code>DailyStep(stepCount: 0, goalStepSnapshot: 5000)</code>

## 링크
- [노션 태스크](https://www.notion.so/oreumi/248ebaa8982b80a68fbbec6dd0110415?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)