### PR TITLE
feat/chatbot response: 동적 테이블뷰 내에서 컨텐츠가 가려지지 않도록 키보드 인터랙션 처리 및 Swift Concurrency로 코드 변경

### DIFF
--- a/Health/Presentation/Chatbot/Chatbot.storyboard
+++ b/Health/Presentation/Chatbot/Chatbot.storyboard
@@ -18,11 +18,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Sjn-mm-DvB">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="728"/>
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="704"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3mU-rj-JGX">
-                                <rect key="frame" x="16" y="691.66666666666663" width="361" height="76.333333333333371"/>
+                                <rect key="frame" x="16" y="707.66666666666663" width="361" height="76.333333333333371"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JcR-5o-DiP">
                                         <rect key="frame" x="0.0" y="0.0" width="361" height="54"/>
@@ -67,8 +67,8 @@
                         <viewLayoutGuide key="safeArea" id="vgf-3o-Tx2"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="3mU-rj-JGX" firstAttribute="bottom" secondItem="vgf-3o-Tx2" secondAttribute="bottom" constant="-16" id="ODB-MH-Tcl"/>
-                            <constraint firstItem="vgf-3o-Tx2" firstAttribute="bottom" secondItem="Sjn-mm-DvB" secondAttribute="bottom" constant="56" id="RqY-8N-hsN"/>
+                            <constraint firstItem="3mU-rj-JGX" firstAttribute="bottom" secondItem="vgf-3o-Tx2" secondAttribute="bottom" id="ODB-MH-Tcl"/>
+                            <constraint firstItem="vgf-3o-Tx2" firstAttribute="bottom" secondItem="Sjn-mm-DvB" secondAttribute="bottom" constant="80" id="RqY-8N-hsN"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="top" secondItem="bIH-9k-yXg" secondAttribute="top" id="eXd-xE-YDp"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" id="ioe-9z-joi"/>
                             <constraint firstItem="vgf-3o-Tx2" firstAttribute="trailing" secondItem="3mU-rj-JGX" secondAttribute="trailing" constant="16" id="kHh-e7-Smv"/>

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -8,351 +8,339 @@
 import UIKit
 import Network
 
-class ChatbotViewController: CoreGradientViewController {
-	// 뷰모델 생성
+/// Alan 챗 화면 컨트롤러.
+///
+/// - 키보드 프레임 변화: **단일 노티(`keyboardWillChangeFrame`)**로 show/hide/패닝까지 처리
+/// - 로직 분리: 입력창 제약 / 테이블 inset / 자동 스크롤 **역할 분리**
+/// - 스크롤 정책 :
+///   - **처음 키보드 present**, **메시지 전송**, **AI 응답 도착** → 강제 스크롤
+///   - 그 외(키보드 이동/패닝) - 하단 근처 & 드래깅 아님일 때만 스크롤
+@MainActor
+final class ChatbotViewController: CoreGradientViewController {
+
+	// MARK: - Outlets & Dependencies
+
 	private let viewModel = AlanViewModel()
-	
-	@IBOutlet weak var tableView: UITableView!
-	@IBOutlet weak var containerViewBottomConstraint: NSLayoutConstraint!
-	@IBOutlet weak var chattingInputStackView: UIStackView!
-	@IBOutlet weak var chattingContainerStackView: UIStackView!
-	@IBOutlet weak var chattingTextField: UITextField!
-	@IBOutlet weak var sendButton: UIButton!
-	
+
+	@IBOutlet private weak var tableView: UITableView!
+	@IBOutlet private weak var containerViewBottomConstraint: NSLayoutConstraint!
+	@IBOutlet private weak var chattingInputStackView: UIStackView!
+	@IBOutlet private weak var chattingContainerStackView: UIStackView!
+	@IBOutlet private weak var chattingTextField: UITextField!
+	@IBOutlet private weak var sendButton: UIButton!
+
+	// MARK: - Data
+
+	/// 현재 대화에 표시되는 메시지 목록
 	private var messages: [ChatMessage] = []
 
+	/// 고정 헤더 챗봇 타이틀
 	private let hasFixedHeader = true
-	// 네트워크 상태 변화 구독을 위한 Task
+
+	// MARK: - Keyboard State
+
 	private var networkStatusObservationTask: Task<Void, Never>?
-	// 키보드 실제 높이 상태
+
+	/// 현재 키보드 높이
 	private var currentKeyboardHeight: CGFloat = 0
-	
+	/// 직전 키보드 높이 — 최초 present 여부 판단에 사용
+	private var previousKeyboardHeight: CGFloat = 0
+
+	/// 키보드와 입력창 사이에 둘 여유 버퍼
+	private let bottomBuffer: CGFloat = 8
+
+	// MARK: - Lifecycle
+
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
 		setupAttribute()
 		setupConstraints()
 		setupTableView()
 		setupKeyboardObservers()
 		setupTapGesture()
 	}
-	
+
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		
 		navigationController?.setNavigationBarHidden(true, animated: animated)
 	}
-	
+
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
-		
 		navigationController?.setNavigationBarHidden(false, animated: animated)
 	}
 	
+	/// 화면이 사라질 때 메모리 정리(Actor 격리 안전 영역)
+	/// - Note: `deinit` 대신 여기서 Task 취소를 수행하여 Swift 6 경고를 제거
+	override func viewDidDisappear(_ animated: Bool) {
+		super.viewDidDisappear(animated)
+		networkStatusObservationTask?.cancel()
+		networkStatusObservationTask = nil
+	}
+
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
-		
+		// 키보드가 없을 때만 기본 inset 복원
 		if currentKeyboardHeight == 0 {
 			updateTableViewContentInset()
 		}
 	}
-	
+
 	override func initVM() {
 		super.initVM()
 		bindViewModel()
 	}
-	
-	override func setupHierarchy() {
-		
+
+	/// ViewModel의 이벤트를 바인딩
+	/// - AI 응답이 도착하면 메시지를 추가하고 필요 시 스크롤
+	private func bindViewModel() {
+		viewModel.didReceiveResponseText = { [weak self] text in
+			guard let self else { return }
+			Task { @MainActor in
+				self.appendAIResponseAndScroll(text)
+			}
+		}
 	}
-	
+
+	// MARK: - UI Setup
+
 	override func setupAttribute() {
 		applyBackgroundGradient(.midnightBlack)
 		chattingTextField.autocorrectionType = .no
 		chattingTextField.delegate = self
-		
 		setupStackViewStyles()
-		
 		automaticallyAdjustsScrollViewInsets = false
 	}
-	
-	@IBAction func sendButtonTapped(_ sender: UIButton) {
-		sendMessage()
-	}
-	
-	private func bindViewModel() {
-		viewModel.didReceiveResponseText = { [weak self] responseText in
-			guard let self = self else { return }
-			Task { @MainActor in
-				self.handleAIResponse(responseText)
-			}
-		}
-	}
-	
-	private func handleAIResponse(_ responseText: String) {
-		let aiMessage = ChatMessage(text: responseText, type: .ai)
-		messages.append(aiMessage)
-		
-		let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
-		let indexPath = IndexPath(row: insertIndex, section: 0)
 
-		if #available(iOS 17.0, *) {
-			tableView.performBatchUpdates {
-				tableView.insertRows(at: [indexPath], with: .bottom)
-			} completion: { _ in
-				// 셀 추가 후 스크롤
-				Task { @MainActor in
-					try await Task.sleep(for: .milliseconds(50))
-					self.scrollToBottom()
-				}
-			}
-		} else {
-			tableView.insertRows(at: [indexPath], with: .bottom)
-			DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-				self.scrollToBottom()
-			}
-		}
+	private func setupStackViewStyles() {
+		chattingContainerStackView.layer.cornerRadius = 12
+		chattingContainerStackView.layer.masksToBounds = true
+		chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
+		chattingContainerStackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+
+		chattingInputStackView.backgroundColor = .boxBg
+		chattingInputStackView.layer.cornerRadius = 12
+		chattingInputStackView.layer.masksToBounds = true
+		chattingInputStackView.layer.borderColor = UIColor.buttonText.cgColor
+		chattingInputStackView.layer.borderWidth = 1.0
+
+		chattingTextField.backgroundColor = .clear
+		chattingTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 44))
+		chattingTextField.leftViewMode = .always
+		chattingTextField.attributedPlaceholder = NSAttributedString(
+			string: "걸어봇에게 물어보세요.",
+			attributes: [.foregroundColor: UIColor.buttonBackground.withAlphaComponent(0.5)]
+		)
 	}
-	
-	private func handleNetworkError(with error: Error) {
-		let networkError: NetworkError
-		
-		if let castedError = error as? NetworkError {
-			networkError = castedError
-		} else if let urlError = error as? URLError {
-			switch urlError.code {
-			case .notConnectedToInternet:
-				networkError = .notConnectedToInternet
-			case .timedOut:
-				networkError = .timedOut
-			default:
-				networkError = .requestFailed(urlError)
-			}
-		} else {
-			// NetworkError로 캐스팅할 수 없는 경우, 알 수 없는 오류로 처리
-			networkError = .unknown
-		}
-		
-		let errorMessage = networkError.localizedDescription
-		
-		// 챗봇 응답으로 에러 메시지 추가
-		let errorResponse = ChatMessage(text: errorMessage, type: .ai)
-		messages.append(errorResponse)
-		
-		let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
-		let indexPath = IndexPath(row: insertIndex, section: 0)
-		tableView.insertRows(at: [indexPath], with: .bottom)
-		
-		scrollToBottom()
-		
-		showToast(message: errorMessage)
-	}
-	
-	/// NetworkMonitor를 사용해 네트워크 상태 변화 감지하고 토스트 메시지 표시하기 위함
-	private func setupNetworkMonitoring() {
-		networkStatusObservationTask = Task {
-			do {
-				for await isConnected in await NetworkMonitor.shared.networkStatusStream() {
-					if isConnected {
-						// 연결이 복구되었을 때 토스트 메시지 표시
-						await MainActor.run {
-							self.showToast(message: "네트워크 연결이 복구되었습니다.")
-						}
-					} else {
-						// 연결이 끊겼을 때 토스트 메시지 표시
-						let errorMessage = NetworkError.notConnectedToInternet.errorDetailMsgs
-						await MainActor.run {
-							self.showToast(message: errorMessage)
-						}
-					}
-				}
-			} catch {
-				// 스트림 처리 중 오류 발생 시 (예: Task.cancel()로 인한 종료)
-				print("네트워크 상태 스트림 오류: \(error.localizedDescription)")
-			}
-		}
-	}
-	
+
 	private func setupTableView() {
 		tableView.delegate = self
 		tableView.dataSource = self
 		tableView.backgroundColor = .clear
 		tableView.separatorStyle = .none
 		tableView.keyboardDismissMode = .interactive
-		
+
 		if #available(iOS 17.0, *) {
 			tableView.selfSizingInvalidation = .enabledIncludingConstraints
 		}
-		
+
 		tableView.contentInsetAdjustmentBehavior = .never
-		
-		// 동적 높이를 위한 설정
 		tableView.estimatedRowHeight = 60
 		tableView.rowHeight = UITableView.automaticDimension
-		
+
 		tableView.register(ChatbotHeaderTitleCell.self, forCellReuseIdentifier: ChatbotHeaderTitleCell.id)
-		let bubbleNib = BubbleViewCell.nib
-		tableView.register(bubbleNib, forCellReuseIdentifier: BubbleViewCell.id)
-		let aiResponseNib = AIResponseCell.nib
-		tableView.register(aiResponseNib, forCellReuseIdentifier: AIResponseCell.id)
-		
+		tableView.register(BubbleViewCell.nib, forCellReuseIdentifier: BubbleViewCell.id)
+		tableView.register(AIResponseCell.nib, forCellReuseIdentifier: AIResponseCell.id)
+
 		updateTableViewContentInset()
 	}
-	
+
+	/// 키보드가 없을 때 적용하는 기본 inset 값 계산
 	private func updateTableViewContentInset() {
-		// 입력창 높이를 실시간으로 계산
 		let inputContainerHeight = chattingContainerStackView.frame.height
-		let safeAreaBottom = view.safeAreaInsets.bottom
-		let bottomInset = max(inputContainerHeight + 32, 100) // 최소 80 보장
-		
+		let bottomInset = max(inputContainerHeight + 32, 100)
 		tableView.contentInset = UIEdgeInsets(top: 32, left: 0, bottom: bottomInset, right: 0)
 		tableView.scrollIndicatorInsets = tableView.contentInset
 	}
-	
-	private func setupStackViewStyles() {
-		chattingContainerStackView.layer.cornerRadius = 12
-		chattingContainerStackView.layer.masksToBounds = true
-		chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
-		chattingContainerStackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-		
-		chattingInputStackView.backgroundColor = .boxBg
-		chattingInputStackView.layer.cornerRadius = 12
-		chattingInputStackView.layer.masksToBounds = true
-		chattingInputStackView.layer.borderColor = UIColor.buttonText.cgColor
-		chattingInputStackView.layer.borderWidth = 1.0
-		
-		// TextField 설정
-		chattingTextField.backgroundColor = .clear
-		chattingTextField.isUserInteractionEnabled = true
-		chattingTextField.isEnabled = true
-		
-		// 좌측 여백
-		chattingTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 44))
-		chattingTextField.leftViewMode = .always
-		
-		let placeholderText = "걸어봇에게 물어보세요."
-		let placeholderColor = UIColor.buttonBackground.withAlphaComponent(0.5)
-		
-		chattingTextField.attributedPlaceholder = NSAttributedString(
-			string: placeholderText,
-			attributes: [NSAttributedString.Key.foregroundColor: placeholderColor]
-		)
+
+	private func setupTapGesture() {
+		view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard)))
 	}
-	
+
+	// MARK: - Keyboard Handling
+
+	/// 키보드 높이 변화를 감지해 레이아웃과 스크롤을 업데이트
+	/// - 하이브리드 자동 스크롤 규칙:
+	///   - **처음 present**: 무조건 최신 메시지로 스크롤
+	///   - 그 외: near-bottom & not-dragging일 때만 스크롤
 	private func setupKeyboardObservers() {
 		NotificationCenter.default.addObserver(
 			forName: UIResponder.keyboardWillChangeFrameNotification,
 			object: nil,
-			queue: nil) { [weak self] notification in
-				self?.handleKeyboardFrameChange(notification)
-			}
+			queue: .main
+		) { [weak self] noti in
+			self?.onKeyboardFrameChanged(noti)
+		}
 	}
-	private func handleKeyboardFrameChange(_ notification: Notification) {
-		guard let info = notification.userInfo,
-			  let duration = info[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
-			  let curve = info[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt,
-			  let frame = (info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else { return }
-		
-		let keyboardHeight = view.convert(frame, from: nil).intersection(view.bounds).height
-		self.currentKeyboardHeight = keyboardHeight
-		
-		let safeAreaBottomInset = view.safeAreaInsets.bottom
-		let isStackViewFirst = containerViewBottomConstraint.firstItem === chattingContainerStackView
-		
-		UIView.animate(
-			withDuration: duration,
-			delay: 0,
-			options: UIView.AnimationOptions(rawValue: curve << 16)
-		) {
-			if keyboardHeight <= 0 {
-				// dismiss
-				self.containerViewBottomConstraint.constant = isStackViewFirst ? -48 : 48
-				self.updateTableViewContentInset()
-			} else {
-				// present
-				self.containerViewBottomConstraint.constant = isStackViewFirst
-					? -(keyboardHeight - safeAreaBottomInset)
-					:  (keyboardHeight - safeAreaBottomInset)
 
-				// 최신 레이아웃 적용 후 입력창 높이로 inset 계산
-				self.view.layoutIfNeeded()
-				let inputHeight = self.chattingContainerStackView.frame.height
-				let bottomInset = keyboardHeight + inputHeight + 8
-				self.tableView.contentInset = UIEdgeInsets(top: 32, left: 0, bottom: bottomInset, right: 0)
-				self.tableView.scrollIndicatorInsets = self.tableView.contentInset
-			}
+	private func onKeyboardFrameChanged(_ n: Notification) {
+		guard
+			let info = n.userInfo,
+			let duration = info[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+			let curve = info[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt,
+			let endFrame = (info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+		else { return }
+
+		let height = view.convert(endFrame, from: nil).intersection(view.bounds).height
+
+		let wasHidden = (currentKeyboardHeight == 0)
+		let willShow  = (height > 0)
+		let isFirstPresent = wasHidden && willShow
+
+		previousKeyboardHeight = currentKeyboardHeight
+		currentKeyboardHeight  = height
+
+		UIView.animate(withDuration: duration,
+					   delay: 0,
+					   options: UIView.AnimationOptions(rawValue: curve << 16)) {
+			self.updateInputContainerConstraint(forKeyboardHeight: height)
+			self.view.layoutIfNeeded()
+			self.updateTableInsets(forKeyboardHeight: height)
 		} completion: { _ in
-			DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-				self.scrollToBottom()
+			Task { @MainActor in
+				try await Task.sleep(for: .milliseconds(40))
+				if isFirstPresent {
+					self.scrollToBottomIfNeeded(force: true)
+				} else {
+					self.scrollToBottomIfNeeded()
+				}
 			}
 		}
 	}
-	
-	private func setupTapGesture() {
-		let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-		view.addGestureRecognizer(tapGesture)
+
+	/// 입력창 하단 제약을 키보드 높이에 맞춰 조정
+	private func updateInputContainerConstraint(forKeyboardHeight h: CGFloat) {
+		let safe = view.safeAreaInsets.bottom
+		let isStackViewFirst = containerViewBottomConstraint.firstItem === chattingContainerStackView
+		if h <= 0 {
+			containerViewBottomConstraint.constant = isStackViewFirst ? -48 : 48
+		} else {
+			containerViewBottomConstraint.constant = isStackViewFirst ? -(h - safe) : (h - safe)
+		}
 	}
-	
-	private func sendMessage() {
-		guard let text = chattingTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-			  !text.isEmpty else { return }
-		
-		// 사용자 메시지 추가
-		let userMessage = ChatMessage(text: text, type: .user)
-		messages.append(userMessage)
-		
-		chattingTextField.text = ""
-		
-		// 테이블뷰 업데이트
-		let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
-		let indexPath = IndexPath(row: insertIndex, section: 0)
-		tableView.insertRows(at: [indexPath], with: .bottom)
-		
-		// 최신 메시지로 스크롤
+
+	/// 키보드가 있을 때 tableView inset 업데이트 (입력창 + 버퍼 포함)
+	private func updateTableInsets(forKeyboardHeight h: CGFloat) {
+		if h <= 0 {
+			updateTableViewContentInset()
+			return
+		}
+		let inputH = chattingContainerStackView.frame.height
+		let bottomInset = h + inputH + bottomBuffer
+		tableView.contentInset = UIEdgeInsets(top: 32, left: 0, bottom: bottomInset, right: 0)
+		tableView.scrollIndicatorInsets = tableView.contentInset
+	}
+
+	// MARK: - Auto Scroll
+
+	/// 필요 시만 또는 강제로 스크롤을 하단으로 이동
+	private func scrollToBottomIfNeeded(force: Bool = false) {
+		guard force || shouldAutoScroll() else { return }
 		scrollToBottom()
-		
-		sendButton.isEnabled = false
-		sendButton.alpha = 0.5
-		
-		// API 호출
-		Task {
-			await viewModel.sendQuestion(text)
-			
-			await MainActor.run {
-				self.sendButton.isEnabled = true
-				self.sendButton.alpha = 1
-			}
-			if let errorMessageString = viewModel.errorMessage {
-				let errorResponse = ChatMessage(text: errorMessageString, type: .ai)
-				messages.append(errorResponse)
-				
-				let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
-				let indexPath = IndexPath(row: insertIndex, section: 0)
-				tableView.insertRows(at: [indexPath], with: .bottom)
-				
-				scrollToBottom()
-				showToast(message: errorMessageString)
-			}
-		}
 	}
-	
+
+	/// 자동 스크롤 가능 여부 판단
+	/// - 드래그/감속 중이면 false
+	/// - 하단 근처인지 threshold로 판단
+	private func shouldAutoScroll() -> Bool {
+		if tableView.isDragging || tableView.isDecelerating { return false }
+		return isNearBottom(threshold: 120)
+	}
+
+	private func isNearBottom(threshold: CGFloat) -> Bool {
+		let visibleHeight = tableView.bounds.height
+			- tableView.adjustedContentInset.top
+			- tableView.adjustedContentInset.bottom
+		let offsetY = tableView.contentOffset.y
+		let maxVisibleY = offsetY + visibleHeight
+		return maxVisibleY >= (tableView.contentSize.height - threshold)
+	}
+
+	/// tableView를 가장 하단 메시지로 스크롤
 	private func scrollToBottom() {
 		let totalRows = hasFixedHeader ? messages.count + 1 : messages.count
 		guard totalRows > 0 else { return }
 		let lastIndexPath = IndexPath(row: totalRows - 1, section: 0)
 		tableView.scrollToRow(at: lastIndexPath, at: .bottom, animated: true)
 	}
-	
+
+	// MARK: - Actions
+
+	@IBAction private func sendButtonTapped(_ sender: UIButton) {
+		sendMessage()
+	}
+
+	/// 사용자 메시지를 추가하고 서버로 전송
+	/// - 전송 후에는 무조건 최신 메시지로 스크롤
+	private func sendMessage() {
+		guard let text = chattingTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+			  !text.isEmpty else { return }
+
+		messages.append(ChatMessage(text: text, type: .user))
+		chattingTextField.text = ""
+
+		let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
+		let indexPath = IndexPath(row: insertIndex, section: 0)
+		tableView.insertRows(at: [indexPath], with: .bottom)
+		scrollToBottomIfNeeded(force: true)
+
+		sendButton.isEnabled = false
+		sendButton.alpha = 0.5
+
+		Task {
+			await viewModel.sendQuestion(text)
+			sendButton.isEnabled = true
+			sendButton.alpha = 1
+			if let error = viewModel.errorMessage {
+				appendAIResponseAndScroll(error)
+				showToast(message: error)
+			}
+		}
+	}
+
+	/// AI 응답을 추가하고 강제 스크롤
+	private func appendAIResponseAndScroll(_ text: String) {
+		messages.append(ChatMessage(text: text, type: .ai))
+		let insertIndex = hasFixedHeader ? messages.count : messages.count - 1
+		let indexPath = IndexPath(row: insertIndex, section: 0)
+
+		if #available(iOS 17.0, *) {
+			tableView.performBatchUpdates({
+				tableView.insertRows(at: [indexPath], with: .bottom)
+			}, completion: { _ in
+				Task { @MainActor in
+					try await Task.sleep(for: .milliseconds(50))
+					self.scrollToBottomIfNeeded(force: true)
+				}
+			})
+		} else {
+			tableView.insertRows(at: [indexPath], with: .bottom)
+			Task { @MainActor in
+				try await Task.sleep(for: .milliseconds(100))
+				self.scrollToBottomIfNeeded(force: true)
+			}
+		}
+	}
+
 	@objc private func dismissKeyboard() {
 		view.endEditing(true)
 	}
-		
-	deinit {
-		NotificationCenter.default.removeObserver(self)
-		// 네트워크 상태 구독 Task 취소
-		
-		networkStatusObservationTask?.cancel()
-	}
+//	viewDidDisappear에서 cancel처리 함 - Swift 6 경고 이슈로 그렇게 처리함
+// TODO: 그치만 정말 deinit을 설정하지 않아도 되는 것은 좀 더 검증이 차후 필요할 것 같음.
+//	deinit {
+//		NotificationCenter.default.removeObserver(self)
+//		networkStatusObservationTask?.cancel()
+//	}
 }
 
 // MARK: - UITableViewDataSource
@@ -426,17 +414,10 @@ extension ChatbotViewController: UITextFieldDelegate {
 	
 	func textFieldDidBeginEditing(_ textField: UITextField) {
 		// 텍스트필드 편집 시작할 때 최신 메시지로 스크롤 해 줌.
-		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-			self.scrollToBottom()
+		Task { @MainActor in
+			try await Task.sleep(for: .milliseconds(300))
+			self.scrollToBottomIfNeeded(force: true)
 		}
-//		Task { @MainActor in
-//			do {
-//				try await Task.sleep(for: .milliseconds(300))
-//				scrollToBottom()
-//			} catch {
-//				print("error", error)
-//			}
-//		}
 	}
 	
 	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleCell.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleCell.swift
@@ -35,6 +35,7 @@ final class ChatbotHeaderTitleCell: CoreTableViewCell {
 			setupConstraints()
 			setupAttribute()
 		}
+		
 	}
 	
 	required init?(coder: NSCoder) {


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) closed 이슈넘버 #61 : 키보드 dismiss 시 스크롤 안되어서 마지막 메시지 가려지는 것 수정

- 키보드가 present로 유지될 때 타이핑해서 스크롤 발생시 가려졌던 부분도 해결
- 키보드 dismiss, present 되었을 때 가려짐 현상, 키보드 높이 상태값 업데이트 반영해 적용
---

## ✅ 변경사항

- 키보드 인셋 계산, notification willShow, willHide로 분리한 것을 Notification 하나에서 처리해 그 안에서 키보드 프레임의 현재 높이값 계산해 scroll되게 함
- MainActor로 선언 concurrency로 최대한 변경
    - 필요한 부분 DocC 주석 달기
    - deinit 대신 viewDidDisappear에서 Task 취소 수행해 Swift6 경고 메시지 제거
    - 키보드 작업할 때, 네트워크 연결 여부 코드 삭제해버림. 차후 커밋 후 이 PR 내에서 추가 예정
---

## 🧪 테스트시 유의 사항
- 본인의 bundle id 설정, api key설정하여 테스트 하시면 됩니다.
- 디버그 모드, 릴리즈 모드 둘다 확인해보시고, 시뮬레이터와 실기기에서도 확인 부탁드려요

---

## 📝 참고

- 기승님의 navigationBar 제약이 컬렉션뷰와 타이틀에 걸려서 뭔가 버튼 인터랙션이 원할하지 않음. 이건 차후 기승님과 해결 예정
- 네트워크 연결 토스터블 코드 지워버렸는데 나중에 별도 PR에서 추가하겠습니다.
---

## 🌈 이미지

| 1  릴리즈 화면 | 2 디버그 화면(키보드 올라왔을때 모습)   |
| :-:| :-: |
|  <img width="300" alt="simulator_screenshot_6B225188-9C4A-48E3-8252-0DAC76994EF7" src="https://github.com/user-attachments/assets/77f6a4b2-667e-4b73-a23c-50c27e0cf8a8" /> |  <img width="300" alt="simulator_screenshot_6B225188-9C4A-48E3-8252-0DAC76994EF7" src="https://github.com/user-attachments/assets/45feb82e-5dd2-4276-877b-79c1bdfdc7cd" />
 |

