### PR TITLE
feat: HealthKitService에 읽기 권한 여부를 확인하는 메서드 추가 구현

### DIFF
--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -252,9 +252,7 @@
 				CODE_SIGN_ENTITLEMENTS = Health/Health.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-
 				DEVELOPMENT_TEAM = "";
-
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "걷기 및 활동 데이터를 분석하여 AI가 맞춤 건강 정보를 제공합니다. 일일 걸음 수, 이동 거리, 활동 에너지를 바탕으로 건강 상태를 파악하고 개인화된 추천을 받기 위해 사용자의 건강 데이터 접근이 필요합니다.";
@@ -292,9 +290,7 @@
 				CODE_SIGN_ENTITLEMENTS = Health/Health.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-        
 				DEVELOPMENT_TEAM = "";
-
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "걷기 및 활동 데이터를 분석하여 AI가 맞춤 건강 정보를 제공합니다. 일일 걸음 수, 이동 거리, 활동 에너지를 바탕으로 건강 상태를 파악하고 개인화된 추천을 받기 위해 사용자의 건강 데이터 접근이 필요합니다.";

--- a/Health/Core/Utils/Extensions/Date+Extension.swift
+++ b/Health/Core/Utils/Extensions/Date+Extension.swift
@@ -152,6 +152,17 @@ extension Date {
 }
 
 extension Date {
+    
+    /// 현재 날짜에서 지정한 일 수를 더하거나 뺀 새로운 날짜를 반환합니다.
+    ///
+    /// - Parameter days: 더하거나 뺄 일 수입니다. 양수면 미래 날짜, 음수면 과거 날짜를 반환합니다.
+    /// - Returns: 계산된 새로운 `Date` 객체. 계산이 불가능한 경우 `nil`을 반환합니다.
+    func addingDays(_ days: Int) -> Date? {
+        calendar.date(byAdding: .day, value: days, to: self)
+    }
+}
+
+extension Date {
 
     /// 주어진 날짜와 특정 캘린더 컴포넌트 단위로 값이 동일한지 비교합니다.
     ///

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -174,16 +174,23 @@ final class ChatbotViewController: CoreGradientViewController {
 	///   - **처음 present**: 무조건 최신 메시지로 스크롤
 	///   - 그 외: near-bottom & not-dragging일 때만 스크롤
 	private func setupKeyboardObservers() {
-		NotificationCenter.default.addObserver(
-			forName: UIResponder.keyboardWillChangeFrameNotification,
-			object: nil,
-			queue: .main
-		) { [weak self] noti in
-			self?.onKeyboardFrameChanged(noti)
-		}
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onKeyboardFrameChanged(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+        
+//		NotificationCenter.default.addObserver(
+//			forName: UIResponder.keyboardWillChangeFrameNotification,
+//			object: nil,
+//			queue: .main
+//		) { [weak self] noti in
+//			self?.onKeyboardFrameChanged(noti)
+//		}
 	}
 
-	private func onKeyboardFrameChanged(_ n: Notification) {
+	@objc private func onKeyboardFrameChanged(_ n: Notification) {
 		guard
 			let info = n.userInfo,
 			let duration = info[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,

--- a/Health/Services/HealthService/MockHealthService.swift
+++ b/Health/Services/HealthService/MockHealthService.swift
@@ -38,14 +38,15 @@ final class MockHealthService: HealthService {
     ///
     /// - Important: `DEBUG` 모드에서는 아무런 동작을 수행하지 않습니다.
     /// 반드시 `RELEASE` 스킴으로 전환 후, 호출하세요.
-    func requestAuthorization() async throws {
+    func requestAuthorization() async throws -> Bool {
+        return true
     }
 
     ///
     /// - Important: `DEBUG` 모드에서는 `.sharingAutorized` 값만 반환합니다.
     /// 반드시 `RELEASE` 스킴으로 전환 후, 호출하세요.
-    func authorizationStatus(for type: HKObjectType) -> HKAuthorizationStatus {
-        .sharingAuthorized
+    func checkHasAnyReadPermission() async -> Bool {
+        return true
     }
 
 

--- a/Health/Services/HealthService/Protocol/HealthService.swift
+++ b/Health/Services/HealthService/Protocol/HealthService.swift
@@ -41,10 +41,16 @@ protocol HealthService {
     /// 사용자의 동의를 받아 HealthKit 데이터 읽기 및 쓰기 권한을 요청합니다.
     /// HealthKit 사용 가능 여부를 확인한 후, 권한 요청을 수행합니다.
     /// - Throws: `HKError.errorHealthDataUnavailable` 또는 권한 요청 실패 시 에러를 던집니다.
-    func requestAuthorization() async throws
+    func requestAuthorization() async throws -> Bool
 
+    /// HealthKit에서 읽기 권한이 부여된 데이터 타입이 하나라도 있는지 비동기적으로 검사합니다.
     ///
-    func authorizationStatus(for type: HKObjectType) -> HKAuthorizationStatus
+    /// 이 메서드는 `typesForAuthorization`에 포함된 모든 HealthKit 데이터 타입에 대해
+    /// 권한 상태를 병렬로 확인합니다. 하나라도 읽기 권한(`.sharingAuthorized`)이 있으면
+    /// `true`를 반환하고, 전혀 없으면 `false`를 반환합니다.
+    ///
+    /// - Returns: 읽기 권한이 하나라도 존재하면 `true`, 아니면 `false`.
+    func checkHasAnyReadPermission() async -> Bool
 
 
     /// 지정한 양적 데이터(identifier)를 기준으로 HealthKit에서 샘플 데이터를 비동기적으로 가져오고,

--- a/Health/Services/NetworkService/Protocol/NetworkService.swift
+++ b/Health/Services/NetworkService/Protocol/NetworkService.swift
@@ -3,6 +3,7 @@ import Foundation
 /// 네트워크 요청을 처리하는 서비스의 프로토콜
 ///
 /// 네트워크 서비스의 기본 인터페이스를 정의하며, 테스트 목적으로 모킹할 수 있도록 합니다.
+@MainActor
 protocol NetworkService {
 
     /// 지정된 엔드포인트로 네트워크 요청을 수행합니다


### PR DESCRIPTION
[Notion Task](https://www.notion.so/oreumi/HealthKitService-24bebaa8982b8011bccae23e58e96861?source=copy_link)

## ✅ 변경사항

- `HealthService`에서 읽기 권한 여부를 확인하는 메서드를 추가로 구현하였습니다. (checkHasAnyReadPermission() 메서드)
- ChatBotViewController와 AlanViewModel에서 발생하는 Swift Concurrency 경고를 제거하였습니다 (완벽하게 해결한 건 아님)

## 📝 참고

@haejaejoon 
@kwondohyun12 

- HealthService에 새롭게 추가된 메서드 꼭 확인해주세요~ 감사합니다.
