### PR TITLE
fix: 캘린더 탭 달력 날짜 border가 다크모드에서는 안보이게 처리

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -74,8 +74,9 @@ final class CalendarDateCell: CoreCollectionViewCell {
             borderLayer.fillColor = UIColor.clear.cgColor
             borderLayer.lineWidth = borderWidth
 
-            // ProgressBar 아래에 border 추가
             circleView.layer.insertSublayer(borderLayer, below: progressBar.layer)
+        } else {
+            borderLayer.removeFromSuperlayer()
         }
     }
 
@@ -97,7 +98,13 @@ final class CalendarDateCell: CoreCollectionViewCell {
             progressBar.isHidden = true
         } else {
             circleView.backgroundColor = UIColor.boxBg
-            borderLayer.isHidden = false
+
+            if traitCollection.userInterfaceStyle == .light {
+                borderLayer.isHidden = false
+            } else {
+                borderLayer.isHidden = true
+            }
+
             progressBar.isHidden = false
             progressBar.progress = CGFloat(currentSteps) / CGFloat(goalSteps)
         }


### PR DESCRIPTION
## 작업내용
| Before | After |
| -- | -- |
| <img width="1206" height="2622" alt="simulator_screenshot_6E0732FF-F826-4001-99CE-F361634D1FEF" src="https://github.com/user-attachments/assets/27631b2b-f041-471e-8908-3a4960948c3d" /> | <img width="1206" height="2622" alt="simulator_screenshot_FFFAF6E6-2222-4545-BCF8-6F8C4B971D74" src="https://github.com/user-attachments/assets/513881ad-7d4a-4338-bc7c-401e795d8b64" /> |

> 간단 수정이라 태스크는 만들지 않았습니다.