### PR TITLE
feat: `DailyGoalRing`, `HealthInfoStack` 및 `HealthInfoCard` 셀에 실제 HealthKit 데이터를 주입 및 건강 데이터 불러오기 실패 시, 예외 UI가 뜨도록 구현

### DIFF
--- a/Health/Core/Views/CircleProgressView/CircleProgressView.swift
+++ b/Health/Core/Views/CircleProgressView/CircleProgressView.swift
@@ -32,7 +32,7 @@ final class CircleProgressView: CoreView {
     }
 
     /// 현재 진행 중인 값을 나타냅니다. 진행률 계산 시 분자로 사용됩니다.
-    var currentValue: Double = 0 {
+    var currentValue: Double? = nil {
         didSet { self.setNeedsLayout() }
     }
 
@@ -100,17 +100,22 @@ final class CircleProgressView: CoreView {
     override func layoutSubviews() {
         drawStrokeCircle()
 
-        var percentageValue = currentValue / totalValue
-        if percentageValue > 1 { percentageValue = 1 }
-        percentageLabel.text = percentageValue
-            .formatted(.percent.precision(.fractionLength(1)))
+        if let currentValue = currentValue {
+            var percentageValue = currentValue / totalValue
+            if percentageValue > 1 { percentageValue = 1 }
+            percentageLabel.text = percentageValue
+                .formatted(.percent.precision(.fractionLength(1)))
 
-        let progressString = "\(currentValue.formatted()) / \(totalValue.formatted())"
-        if let slashIndex = progressString.firstIndex(of: "/") {
-            let index = progressString.index(after: slashIndex)
-            stepProgressLabel.attributedText = NSAttributedString(string: progressString)
-                .foregroundColor(.systemMint, to: progressString[index...])
+            let progressString = "\(currentValue.formatted()) / \(totalValue.formatted())"
+            if let slashIndex = progressString.firstIndex(of: "/") {
+                let index = progressString.index(after: slashIndex)
+                stepProgressLabel.attributedText = NSAttributedString(string: progressString)
+                    .foregroundColor(.systemMint, to: progressString[index...])
+            } else {
+                stepProgressLabel.text = "-"
+            }
         } else {
+            percentageLabel.text = "-"
             stepProgressLabel.text = "-"
         }
     }
@@ -186,7 +191,6 @@ final class CircleProgressView: CoreView {
 
     private func drawStrokeCircle() {
         let adjustedStartAngle = -90.radian
-        let calculatedEndAngle = ((currentValue / totalValue) * 360.0 - 90.0).radian
         
         drawStrokeCircle(
             in: &backgroundGradientLayer,
@@ -196,15 +200,18 @@ final class CircleProgressView: CoreView {
             darkStrokeColors: backgroundDarkColors,
             lineWidth: backgroundLineWidth
         )
-        
-        drawStrokeCircle(
-            in: &foregroundGradientLayer,
-            startAngle: adjustedStartAngle,
-            endAngle: calculatedEndAngle,
-            lightStrokeColors: foregroundLightColors,
-            darkStrokeColors: foregroundDarkColors,
-            lineWidth: foregroundLineWidth
-        )
+
+        if let currentValue = currentValue {
+            let calculatedEndAngle = ((currentValue / totalValue) * 360.0 - 90.0).radian
+            drawStrokeCircle(
+                in: &foregroundGradientLayer,
+                startAngle: adjustedStartAngle,
+                endAngle: calculatedEndAngle,
+                lightStrokeColors: foregroundLightColors,
+                darkStrokeColors: foregroundDarkColors,
+                lineWidth: foregroundLineWidth
+            )
+        }
     }
 }
 

--- a/Health/Core/Views/StatusProgressBarView/StatusProgressBarView.swift
+++ b/Health/Core/Views/StatusProgressBarView/StatusProgressBarView.swift
@@ -130,6 +130,7 @@ final class StatusProgressBarView: UIView {
         xAxisLabelStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         xAxisLabelStackView.subviews.forEach { $0.removeFromSuperview() }
         dotParentView.subviews.forEach { $0.removeFromSuperview() }
+        indicatorDotView.removeFromSuperview()
 
         addGradientLayer(to: progressBarView)
         progressBarView.layer.cornerRadius = progressBarView.bounds.height / 2.0

--- a/Health/Presentation/Dashboard/Content/Enum/DashboardCardType.swift
+++ b/Health/Presentation/Dashboard/Content/Enum/DashboardCardType.swift
@@ -177,7 +177,7 @@ extension DashboardCardType {
 extension DashboardCardType {
 
     ///
-    var higerIsBetter: Bool {
+    var higherIsBetter: Bool {
         switch self {
         case .walkingSpeed, .walkingStepLength:                            return true
         case .walkingAsymmetryPercentage, .walkingDoubleSupportPercentage: return false

--- a/Health/Presentation/Dashboard/Content/Enum/DashboardStackType.swift
+++ b/Health/Presentation/Dashboard/Content/Enum/DashboardStackType.swift
@@ -24,8 +24,8 @@ extension DashboardStackType {
     ///
     var title: String? {
         switch self {
-        case .distanceWalkingRunning:           return "걷기 + 달리기 거리"
-        case .appleExerciseTime:                return "운동하기 시간"
+        case .distanceWalkingRunning:           return "걷기 거리"
+        case .appleExerciseTime:                return "운동 시간"
         case .activeEnergyBurned:               return "활동 에너지"
         case .basalEnergyBurned:                return "휴식 에너지"
         }

--- a/Health/Presentation/Dashboard/Content/Enum/DashboardStackType.swift
+++ b/Health/Presentation/Dashboard/Content/Enum/DashboardStackType.swift
@@ -24,7 +24,7 @@ extension DashboardStackType {
     ///
     var title: String? {
         switch self {
-        case .distanceWalkingRunning:           return "걷기 거리"
+        case .distanceWalkingRunning:           return "걸은 거리"
         case .appleExerciseTime:                return "운동 시간"
         case .activeEnergyBurned:               return "활동 에너지"
         case .basalEnergyBurned:                return "휴식 에너지"

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -29,6 +29,11 @@ final class DashboardViewController: CoreGradientViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        Task {
+            let healthService = DefaultHealthService()
+            try await healthService.requestAuthorization() // - 임시 코드!! 반드시 삭제!! ⚠️
+        }
+
         setupDataSource()
         applySnapshot()
     }
@@ -111,14 +116,22 @@ final class DashboardViewController: CoreGradientViewController {
         snapshot.appendItems([.topBar], toSection: .top)
         snapshot.appendItems([.goalRing(.init()), .stackInfo(.init()), .stackInfo(.init()), .stackInfo(.init())], toSection: .ring)
 
-        snapshot.appendItems(
+        snapshot.appendItems( // TODO: - 아이폰/아이패드에 맞게 분리하기
             [.barCharts(.init(back: .daysBack(7))!),
              .barCharts(.init(back: .monthsBack(12))!)],
             toSection: .charts
         )
 
         snapshot.appendItems([.alanSummary(.init())], toSection: .alan)
-        snapshot.appendItems([.cardInfo(.init()),  .cardInfo(.init()), .cardInfo(.init()), .cardInfo(.init())], toSection: .card)
+
+        snapshot.appendItems(
+            [.cardInfo(.init(cardType: .walkingSpeed, age: 27)),
+             .cardInfo(.init(cardType: .walkingStepLength, age: 27)),
+             .cardInfo(.init(cardType: .walkingAsymmetryPercentage, age: 27)),
+             .cardInfo(.init(cardType: .walkingDoubleSupportPercentage, age: 27))],
+            toSection: .card
+        )
+
         snapshot.appendItems([.text], toSection: .bottom)
         dataSource?.apply(snapshot)
     }

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -113,8 +113,18 @@ final class DashboardViewController: CoreGradientViewController {
 
         var snapshot = NSDiffableDataSourceSnapshot<DashboardContent.Section, DashboardContent.Item>()
         snapshot.appendSections([.top, .ring, .charts, .alan, .card, .bottom])
+
+
         snapshot.appendItems([.topBar], toSection: .top)
-        snapshot.appendItems([.goalRing(.init()), .stackInfo(.init()), .stackInfo(.init()), .stackInfo(.init())], toSection: .ring)
+
+
+        snapshot.appendItems(
+            [.goalRing(.init(goalStepCount: 10_000)), // 실제 목표 걸음 수 데이터 주입하기
+             .stackInfo(.init(stackType: .distanceWalkingRunning)),
+             .stackInfo(.init(stackType: .appleExerciseTime)),
+             .stackInfo(.init(stackType: .activeEnergyBurned))],
+            toSection: .ring
+        )
 
         snapshot.appendItems( // TODO: - 아이폰/아이패드에 맞게 분리하기
             [.barCharts(.init(back: .daysBack(7))!),
@@ -125,7 +135,7 @@ final class DashboardViewController: CoreGradientViewController {
         snapshot.appendItems([.alanSummary(.init())], toSection: .alan)
 
         snapshot.appendItems(
-            [.cardInfo(.init(cardType: .walkingSpeed, age: 27)),
+            [.cardInfo(.init(cardType: .walkingSpeed, age: 27)), // MARK: - 실제 나이 데이터 주입하기
              .cardInfo(.init(cardType: .walkingStepLength, age: 27)),
              .cardInfo(.init(cardType: .walkingAsymmetryPercentage, age: 27)),
              .cardInfo(.init(cardType: .walkingDoubleSupportPercentage, age: 27))],

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -49,9 +49,9 @@ extension AlanActivitySummaryCollectionViewCell {
     func bind(with viewModel: AlanActivitySummaryCellViewModel) {
         Task {
             do {
-                let message = try await viewModel.askAlanToSummarizeActivity()
-                self.summaryLabel.text = message
-                didReceiveAIMessage?(message)
+//                let message = try await viewModel.askAlanToSummarizeActivity()
+//                self.summaryLabel.text = message
+//                didReceiveAIMessage?(message)
             } catch {
                 // TODO: - 예외 UI 코드 작성하기
                 print("🔴 Failed to summarize activity: \(error)")

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -10,7 +10,6 @@ import UIKit
 final class DailyGoalRingCollectionViewCell: CoreCollectionViewCell {
 
     @IBOutlet weak var circleProgressView: CircleProgressView!
-
 }
 
 extension DailyGoalRingCollectionViewCell {
@@ -21,8 +20,9 @@ extension DailyGoalRingCollectionViewCell {
                 circleProgressView.totalValue = viewModel.goalStepCount
                 circleProgressView.currentValue = try await viewModel.fetchStatisticsHKData().value
             } catch {
-                // TODO: - 예외 UI 코드 작성하기
-                print("🔴 Failed to fetch statistics HKData: \(error)")
+                circleProgressView.currentValue = nil
+
+                print("🔴 Failed to fetch statistics HKData: \(error) (DailyGoalRingCell)")
             }
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -38,7 +38,7 @@ extension DashboardBarChartsCollectionViewCell {
         Task {
             do {
                 let hkDatas = try await viewModel.fetchStatisticsCollectionHKDatas(options: .cumulativeSum)
-                let avgData = try await viewModel.fetchStatisticsCollectionHKDatas(options: .discreteAverage)
+                let avgData = hkDatas.reduce(0, { $0 + Int($1.value) }) / hkDatas.count
 
                 // TODO: - 코드 리팩토링하기
                 barChartsView.chartData = prepareChartData(hkDatas, type: viewModel.backType)
@@ -54,7 +54,7 @@ extension DashboardBarChartsCollectionViewCell {
                 // TODO: - 평균값 포매팅 및 글자 폰트 다시 처리하기
 
                 headerLabelView.text = viewModel.headerTitle
-                averageValueLabel.text = (avgData.first?.value.formatted() ?? "0") + "보"
+                averageValueLabel.text = avgData.formatted() + "보"
             } catch {
                 // TODO: - 예외 UI 출력하기
                 print("🔴 Failed to fetch HealthKit Datas: \(error)")

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -38,7 +38,7 @@ extension DashboardBarChartsCollectionViewCell {
         Task {
             do {
                 let hkDatas = try await viewModel.fetchStatisticsCollectionHKDatas(options: .cumulativeSum)
-                let avgData = hkDatas.reduce(0, { $0 + Int($1.value) }) / hkDatas.count
+                let avgData = hkDatas.reduce(0, { $0 + Int($1.value) }) / max(hkDatas.count, 1)
 
                 // TODO: - 코드 리팩토링하기
                 barChartsView.chartData = prepareChartData(hkDatas, type: viewModel.backType)

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -52,25 +52,50 @@ extension HealthInfoCardCollectionViewCell {
 
         Task {
             do {
+                titleLabel.text = viewModel.cardType.title
+                statusProgressBarView.higherIsBetter = viewModel.cardType.higerIsBetter
+                statusProgressBarView.thresholdsValues = viewModel.cardType.thresholdValues(age: viewModel.age)
+
                 let hkData = try await viewModel.fetchStatisticsHealthKitData(options: .mostRecent)
                 let status = viewModel.evaluateGaitStatus(hkData.value)
 
-                titleLabel.text = viewModel.cardType.title
-                valueLabel.attributedText = NSAttributedString(string: "1,000보") // TODO: - 실제 데이터 가져오기
-                    .font(.preferredFont(forTextStyle: .footnote), to: "보")
-                    .foregroundColor(.secondaryLabel, to: "보")
+                let unitString = viewModel.cardType.unitString
+                let formattedValue = switch viewModel.cardType {
+                case .walkingAsymmetryPercentage, .walkingDoubleSupportPercentage: hkData.value * 100.0
+                case .walkingSpeed, .walkingStepLength: hkData.value
+                }
+
+                statusProgressBarView.currentValue = hkData.value
+                statusProgressBarView.numberFormatter = prepareNumberFormatter(type: viewModel.cardType)
+                valueLabel.attributedText = NSAttributedString(string: String(format: "%.1f", formattedValue) + unitString)
+                    .font(.preferredFont(forTextStyle: .footnote), to: unitString)
+                    .foregroundColor(.secondaryLabel, to: unitString)
 
                 gaitStatusLabel.text = status.rawValue
                 gaitStatusLabel.textColor = status.backgroundColor
                 statusContainerView.backgroundColor = status.secondaryBackgroundColor
 
-                statusProgressBarView.currentValue = hkData.value
-                statusProgressBarView.thresholdsValues = viewModel.cardType.thresholdValues(age: 27) // TODO: - 나이 데이터 가져오기
-                statusProgressBarView.higherIsBetter = viewModel.cardType.higerIsBetter
             } catch {
-                // TODO: - UI 예외 처리하기
+                let unitString = viewModel.cardType.unitString
+                valueLabel.attributedText = NSAttributedString(string: "- " + unitString)
+                    .font(.preferredFont(forTextStyle: .footnote), to: unitString)
+                    .foregroundColor(.secondaryLabel, to: unitString)
+                statusContainerView.isHidden = true
+                statusProgressBarView.currentValue = nil
+
                 print("🔴 Failed to fetch HealthKit data: \(error)")
             }
+        }
+    }
+
+    private func prepareNumberFormatter(type: DashboardCardType) -> NumberFormatter? {
+        switch type {
+        case .walkingDoubleSupportPercentage, .walkingAsymmetryPercentage:
+            let nf = NumberFormatter()
+            nf.numberStyle = .percent
+            return nf
+        case .walkingStepLength, .walkingSpeed:
+            return nil
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -53,7 +53,7 @@ extension HealthInfoCardCollectionViewCell {
         Task {
             do {
                 titleLabel.text = viewModel.cardType.title
-                statusProgressBarView.higherIsBetter = viewModel.cardType.higerIsBetter
+                statusProgressBarView.higherIsBetter = viewModel.cardType.higherIsBetter
                 statusProgressBarView.thresholdsValues = viewModel.cardType.thresholdValues(age: viewModel.age)
 
                 let hkData = try await viewModel.fetchStatisticsHealthKitData(options: .mostRecent)

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
@@ -17,19 +17,19 @@
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="V49-SI-zqi">
-                        <rect key="frame" x="12" y="24" width="276" height="158"/>
+                        <rect key="frame" x="16" y="24" width="268" height="158"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="f87-08-Ecs">
-                                <rect key="frame" x="0.0" y="0.0" width="276" height="66"/>
+                                <rect key="frame" x="0.0" y="0.0" width="268" height="66"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" text="보행 보폭" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMV-cm-r7I">
-                                        <rect key="frame" x="0.0" y="0.0" width="276" height="26"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="268" height="26"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QNc-SU-0qE">
-                                        <rect key="frame" x="0.0" y="38" width="276" height="28"/>
+                                        <rect key="frame" x="0.0" y="38" width="268" height="28"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="1,000보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e7A-fc-gRb">
                                                 <rect key="frame" x="0.0" y="0.0" width="98.666666666666671" height="28"/>
@@ -38,7 +38,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ac-L3-PfJ">
-                                                <rect key="frame" x="214.33333333333334" y="0.0" width="61.666666666666657" height="28"/>
+                                                <rect key="frame" x="206.33333333333334" y="0.0" width="61.666666666666657" height="28"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="정상" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPV-e6-f8D">
                                                         <rect key="frame" x="16" y="4" width="29.666666666666671" height="20.333333333333332"/>
@@ -70,7 +70,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5UC-7q-A0l" customClass="StatusProgressBarView" customModule="Health" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="98" width="276" height="60"/>
+                                <rect key="frame" x="0.0" y="98" width="268" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="Abo-23-JHY"/>
                                 </constraints>
@@ -80,10 +80,10 @@
                 </subviews>
             </view>
             <constraints>
-                <constraint firstItem="V49-SI-zqi" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="12" id="8U4-xM-zV6"/>
+                <constraint firstItem="V49-SI-zqi" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="16" id="8U4-xM-zV6"/>
                 <constraint firstAttribute="bottom" secondItem="V49-SI-zqi" secondAttribute="bottom" constant="24" id="JwS-eP-OlZ"/>
                 <constraint firstItem="V49-SI-zqi" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="24" id="NFO-86-2qq"/>
-                <constraint firstAttribute="trailing" secondItem="V49-SI-zqi" secondAttribute="trailing" constant="12" id="ZYu-iy-BEF"/>
+                <constraint firstAttribute="trailing" secondItem="V49-SI-zqi" secondAttribute="trailing" constant="16" id="ZYu-iy-BEF"/>
             </constraints>
             <size key="customSize" width="461" height="253"/>
             <connections>

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -85,7 +85,7 @@ extension HealthInfoStackCollectionViewCell {
             do {
                 let hkDatas = try await viewModel.fetchStatisticsCollectionHKData(options: .cumulativeSum)
 
-                let chartsData = Array(hkDatas.prefix(upTo: 7))
+                let chartsData = Array(hkDatas)
                 let hostingVC = LineChartsHostingController(chartsData: chartsData)
 
                 parent?.addChild(hostingVC, to: chartsContainerView)

--- a/Health/ViewModels/Cells/DailyGoalRingCellViewModel.swift
+++ b/Health/ViewModels/Cells/DailyGoalRingCellViewModel.swift
@@ -14,10 +14,7 @@ final class DailyGoalRingCellViewModel: @unchecked Sendable {
 
     @Injected private var healthService: (any HealthService)
 
-    convenience init() { // TODO: - 생성자 코드 삭제하기
-        self.init(goalStepCount: 1000)
-    }
-
+    ///
     init(
         anchorDate: Date = .now,
         goalStepCount: Int
@@ -26,11 +23,12 @@ final class DailyGoalRingCellViewModel: @unchecked Sendable {
         self.goalStepCount = Double(goalStepCount)
     }
 
+    ///
     func fetchStatisticsHKData() async throws -> HealthKitData {
         try await healthService.fetchStatistics(
             for: .stepCount,
             from: anchorDate.startOfDay(),
-            to: anchorDate.startOfDay().addingDays(1) ?? .now,
+            to: anchorDate.endOfDay(),
             options: .cumulativeSum,
             unit: .count()
         )

--- a/Health/ViewModels/Cells/HealthInfoCardCellViewModel.swift
+++ b/Health/ViewModels/Cells/HealthInfoCardCellViewModel.swift
@@ -15,11 +15,12 @@ final class HealthInfoCardCellViewModel {
 
     @Injected var healthService: (any HealthService)
 
-    convenience init() { // 임시 코드
-        self.init(anchorDate: .now, cardType: .walkingStepLength, age: 27)
-    }
-
+    /// 주어진 기준 날짜, 카드 타입, 나이로 인스턴스를 초기화합니다.
     ///
+    /// - Parameters:
+    ///   - anchorDate: 데이터를 조회할 기준 날짜입니다. 기본값은 현재 시각입니다.
+    ///   - cardType: 대시보드 카드의 유형입니다.
+    ///   - age: 사용자의 나이입니다.
     init(
         anchorDate: Date = .now,
         cardType: DashboardCardType,
@@ -30,22 +31,27 @@ final class HealthInfoCardCellViewModel {
         self.age = age
     }
 
-    /// <#Description#>
-    /// - Parameters:
-    ///   - startDate: <#startDate description#>
-    ///   - endDate: <#endDate description#>
-    /// - Returns: <#description#>
+    /// 기준 시각으로부터 최근 14일간의 HealthKit 통계 데이터를 비동기적으로 조회합니다.
+    ///
+    /// - Parameter options: HealthKit 통계 조회 시 사용할 옵션입니다.
+    /// - Returns: 지정한 기간과 옵션에 해당하는 `HealthKitData` 객체를 반환합니다.
+    /// - Throws: HealthKit 데이터 조회에 실패할 경우 오류를 던집니다.
     func fetchStatisticsHealthKitData(options: HKStatisticsOptions) async throws -> HealthKitData {
-        try await healthService.fetchStatistics(
+        let startDate = (anchorDate.addingDays(-14) ?? anchorDate).startOfDay()
+
+        return try await healthService.fetchStatistics(
             for: cardType.quantityTypeIdentifier,
-            from: anchorDate.startOfDay(),
+            from: startDate,
             to: anchorDate.endOfDay(),
             options: options,
             unit: cardType.unit
         )
     }
 
+    /// 주어진 측정값을 사용자의 나이와 카드 타입 기준에 따라 보행 상태로 평가합니다.
     ///
+    /// - Parameter value: 평가할 측정값입니다.
+    /// - Returns: 평가된 보행 상태(`GaitStatus`)를 반환합니다.
     func evaluateGaitStatus(_ value: Double) -> DashboardCardType.GaitStatus {
         cardType.status(value, age: age)
     }

--- a/Health/ViewModels/Cells/HealthInfoStackCellViewModel.swift
+++ b/Health/ViewModels/Cells/HealthInfoStackCellViewModel.swift
@@ -15,28 +15,13 @@ final class HealthInfoStackCellViewModel {
     let anchorDate: Date
     let stackType: DashboardStackType
 
-    ///
-    var title: String? {
-        stackType.title
-    }
-
-    ///
-    var systemName: String {
-        stackType.systemName
-    }
-
-    ///
-    var unitString: String? {
-        stackType.unit.unitString
-    }
-
     @Injected var healthService: (any HealthService)
 
-    convenience init() { // 임시 코드
-        self.init(stackType: .activeEnergyBurned)
-    }
-
+    /// 주어진 기준 날짜와 스택 타입으로 인스턴스를 초기화합니다.
     ///
+    /// - Parameters:
+    ///   - anchorDate: 데이터를 조회할 기준 날짜입니다. 기본값은 현재 시각입니다.
+    ///   - stackType: 대시보드 스택의 유형입니다.
     init(
         anchorDate: Date = .now,
         stackType: DashboardStackType
@@ -44,13 +29,13 @@ final class HealthInfoStackCellViewModel {
         self.anchorDate = anchorDate
         self.stackType = stackType
     }
-    
-    /// <#Description#>
-    /// - Parameters:
-    ///   - startDate: <#startDate description#>
-    ///   - endDate: <#endDate description#>
-    /// - Returns: <#description#>
-    func fetchStatisticsHKData(options: HKStatisticsOptions) async throws -> HealthKitData {
+
+    /// 기준 시각 하루 동안의 HealthKit 통계 데이터를 비동기적으로 조회합니다.
+    ///
+    /// - Parameter options: HealthKit 통계 조회 시 사용할 옵션입니다. 기본값은 `.cumulativeSum`입니다.
+    /// - Returns: 조회된 `HealthKitData` 객체를 반환합니다.
+    /// - Throws: HealthKit 데이터 조회에 실패할 경우 오류를 던집니다.
+    func fetchStatisticsHKData(options: HKStatisticsOptions = .cumulativeSum) async throws -> HealthKitData {
         try await healthService.fetchStatistics(
             for: stackType.quantityTypeIdentifier,
             from: anchorDate.startOfDay(),
@@ -59,19 +44,23 @@ final class HealthInfoStackCellViewModel {
             unit: stackType.unit
         )
     }
-    
-    /// <#Description#>
+
+    /// 기준 시각으로부터 최근 7일간의 HealthKit 통계 컬렉션 데이터를 비동기적으로 조회합니다.
+    ///
     /// - Parameters:
-    ///   - startDate: <#startDate description#>
-    ///   - endDate: <#endDate description#>
-    /// - Returns: <#description#>
+    ///   - options: HealthKit 통계 조회 시 사용할 옵션입니다.
+    ///   - intervalComponents: 통계 데이터를 구간별로 나누는 시간 간격입니다. 기본값은 1일입니다.
+    /// - Returns: 조회된 `HealthKitData` 객체 배열을 반환합니다.
+    /// - Throws: HealthKit 데이터 조회에 실패할 경우 오류를 던집니다.
     func fetchStatisticsCollectionHKData(
         options: HKStatisticsOptions,
         interval intervalComponents: DateComponents = .init(day: 1)
     ) async throws -> [HealthKitData] {
-        try await healthService.fetchStatisticsCollection(
+        let startDate = (anchorDate.addingDays(-7) ?? anchorDate).startOfDay()
+
+        return try await healthService.fetchStatisticsCollection(
             for: stackType.quantityTypeIdentifier,
-            from: anchorDate.startOfDay(),
+            from: startDate,
             to: anchorDate.endOfDay(),
             options: options,
             interval: intervalComponents,


### PR DESCRIPTION
[Notion Task](https://www.notion.so/HealthInfoCard-DailyGoalRing-UI-24cebaa8982b8028bc22df1294951a6d?source=copy_link)

## ✅ 변경사항

- `StatusProgressBarView`에서 현재 값으로 `nil`을 전달하면 Dot Indicator가 사라지지 않는 문제를 수정하였습니다.
- `CircleProgressView`에서 현재 값으로 `nil`을 전달하면 예외 UI (-)가 뜨도록 로직을 수정하였습니다.
- `DailyGoalRing`, `HealthInfoStack` 및 `HealthInfoCard` 셀에 실제 HealthKit 데이터를 주입 및 HealthKit 데이터 불러오기 실패 시, 예외 UI가 뜨도록 구현하였습니다.

---

## 📝 참고

- 건강 데이터 불러오기 실패 시, 단순히 대시(-) 처리를 하고 있습니다. 추후 더 좋은 방안 강구해보겠습니다.
- 다음 작업으로 `Bar Charts`와 `AI 요약` 셀에 실제 데이터를 주입 · 예외 처리 작업을 할 예정입니다.
- 현재 각 셀에서 HealthKit에 접근해 데이터를 가져오고 있는데, `DashboardViewModel`에서 한꺼번에 건강 데이터를 모두 가져온 뒤 셀에 뿌리는 식으로 개선할 예정입니다.

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  ![IMG_170B9156BC46-1](https://github.com/user-attachments/assets/f75a2b66-0ead-4527-b992-9883ef2df07f)  |   <img width="1179" height="2556" alt="IMG_0441" src="https://github.com/user-attachments/assets/84329207-2739-4532-98f9-4f34f57e44de" />  |
| ![IMG_527B185C06CB-1](https://github.com/user-attachments/assets/a21c7a33-b9d0-4a5f-b089-744a1797a610) |
