### PR TITLE
refactor: Calendar 코드 책임 분리를 위한 LayoutManager, ScrollManager 추가

### DIFF
--- a/Health/Presentation/Calendar/Managers/CalendarLayoutManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarLayoutManager.swift
@@ -1,0 +1,93 @@
+import UIKit
+
+/// 달력 컬렉션뷰의 레이아웃 생성을 담당하는 매니저
+@MainActor
+final class CalendarLayoutManager {
+    
+    /// 메인 달력 컬렉션뷰의 레이아웃을 생성합니다.
+    ///
+    /// 화면 크기와 기기 특성에 따라 1열 또는 2열 레이아웃으로 구성됩니다.
+    /// 각 월 셀의 높이는 헤더, 요일, 날짜 영역을 모두 포함하여 계산됩니다.
+    ///
+    /// - Returns: 메인 달력용 `UICollectionViewLayout` 인스턴스
+    static func createMainLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { _, env in
+            // 아이패드 등 큰 화면에서는 2열, 그 외에는 1열로 표시
+            let isTwoColumn = env.traitCollection.horizontalSizeClass == .regular
+            && env.container.effectiveContentSize.width >= 700
+            let columns: CGFloat = isTwoColumn ? 2 : 1
+
+            // 섹션 및 아이템 간격 설정
+            let sectionInset = UICollectionViewConstant.defaultInset
+            let itemInset = UICollectionViewConstant.defaultItemInset
+
+            // 각 열의 가용 너비 계산
+            let totalWidth = env.container.effectiveContentSize.width
+            let availableWidth = totalWidth - (sectionInset * 2) - (isTwoColumn ? itemInset : 0)
+            let columnWidth = availableWidth / columns
+
+            // 월 셀의 높이 계산 (헤더 + 요일 + 날짜 영역)
+            let headerHeight: CGFloat = 28
+            let weekdayHeight: CGFloat = 20
+            let verticalSpacing: CGFloat = 16 * 2
+            let daySize: CGFloat = columnWidth / 7.0
+            let numberOfRows: CGFloat = 6 // 고정
+            let monthCellHeight = headerHeight + weekdayHeight + verticalSpacing + daySize * numberOfRows
+
+            // 아이템 크기 설정 (너비는 비율, 높이는 절대값)
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0 / columns),
+                heightDimension: .absolute(monthCellHeight)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+            // 그룹 크기 설정 (전체 너비, 계산된 높이)
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(monthCellHeight)
+            )
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: groupSize,
+                subitems: Array(repeating: item, count: Int(columns))
+            )
+            group.interItemSpacing = .fixed(itemInset)
+
+            // 섹션 설정 (여백 및 그룹 간 간격)
+            let section = NSCollectionLayoutSection(group: group)
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: sectionInset,
+                leading: sectionInset,
+                bottom: sectionInset,
+                trailing: sectionInset
+            )
+            section.interGroupSpacing = 50
+            return section
+        }
+    }
+
+    /// 월별 날짜 컬렉션뷰의 레이아웃을 생성합니다.
+    ///
+    /// `CalendarMonthCell` 내부에서 사용되는 7×6 그리드 레이아웃을 생성합니다.
+    /// 각 날짜 셀은 정사각형 모양으로 표시됩니다.
+    ///
+    /// - Returns: 날짜 그리드용 `UICollectionViewLayout` 인스턴스
+    static func createDateLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0 / 7.0),
+            heightDimension: .fractionalWidth(1.0 / 7.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalWidth(1.0 / 7.0)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: Array(repeating: item, count: 7)
+        )
+
+        let section = NSCollectionLayoutSection(group: group)
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}

--- a/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
@@ -1,0 +1,85 @@
+import UIKit
+
+/// 달력 컬렉션뷰의 스크롤 동작을 관리하는 매니저
+@MainActor
+final class CalendarScrollManager {
+
+    private weak var calendarVM: CalendarViewModel?
+    private weak var collectionView: UICollectionView?
+
+    /// 첫 번째 스크롤(현재 월로 이동) 완료 여부
+    private(set) var didScrollToCurrent = false
+
+    /// 초기 스크롤이 완전히 완료되었는지 여부 (무한 스크롤 허용 조건)
+    private(set) var didFinishInitialScroll = false
+
+    init(calendarVM: CalendarViewModel, collectionView: UICollectionView) {
+        self.calendarVM = calendarVM
+        self.collectionView = collectionView
+    }
+
+    /// `viewDidLayoutSubviews`에서 호출되는 메서드
+    ///
+    /// 최초 1회만 현재 월로 스크롤하고 무한 스크롤을 활성화합니다.
+    /// 레이아웃이 완전히 설정된 후에 호출되어야 정확한 스크롤 위치를 계산할 수 있습니다.
+    func handleViewDidLayoutSubviews() {
+        if !didScrollToCurrent {
+            scrollToCurrentMonth()
+            didScrollToCurrent = true
+            didFinishInitialScroll = true
+        }
+    }
+
+    /// `viewWillAppear`에서 호출되는 메서드
+    ///
+    /// 이미 초기 스크롤을 한 상태에서만 현재 월 위치를 재조정합니다.
+    /// 다른 화면에서 돌아왔을 때 현재 월이 제대로 표시되도록 보장합니다.
+    func handleViewWillAppear() {
+        if didScrollToCurrent {
+            scrollToCurrentMonth()
+        }
+    }
+
+    /// 스크롤 시 무한 스크롤을 처리합니다.
+    ///
+    /// 상단 또는 하단 임계점에 도달하면 추가 데이터를 비동기로 로드합니다.
+    /// 초기 스크롤이 완료되기 전에는 무한 스크롤이 비활성화됩니다.
+    ///
+    /// - Parameter scrollView: 스크롤 이벤트가 발생한 스크롤뷰
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // 초기 스크롤이 완료되기 전에는 무한 스크롤 비활성화
+        guard didFinishInitialScroll else { return }
+
+        let loadThreshold: CGFloat = 200
+        let offsetY = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let visibleHeight = scrollView.bounds.height
+
+        // 상단 근처 스크롤 시 과거 데이터 로드
+        if offsetY < loadThreshold {
+            Task {
+                await calendarVM?.loadMoreTop()
+            }
+        }
+
+        // 하단 근처 스크롤 시 미래 데이터 로드
+        if offsetY > contentHeight - visibleHeight - loadThreshold {
+            Task {
+                await calendarVM?.loadMoreBottom()
+            }
+        }
+    }
+}
+
+private extension CalendarScrollManager {
+
+    /// 현재 월로 스크롤합니다.
+    func scrollToCurrentMonth() {
+        guard let collectionView = collectionView,
+              let calendarVM,
+              let indexPath = calendarVM.indexOfCurrentMonth() else {
+            return
+        }
+        collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+    }
+}

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -5,14 +5,14 @@ final class CalendarMonthCell: CoreCollectionViewCell {
     @IBOutlet weak var yearMonthLabel: UILabel!
     @IBOutlet weak var dateCollectionView: UICollectionView!
     @IBOutlet weak var dateCollectionViewHeightConstraint: NSLayoutConstraint!
-    
+
     private var datesWithBlank: [Date] = []
 
     override func setupAttribute() {
         super.setupAttribute()
         dateCollectionView.dataSource = self
         dateCollectionView.delegate = self
-        dateCollectionView.collectionViewLayout = createLayout()
+        dateCollectionView.collectionViewLayout = CalendarLayoutManager.createDateLayout()
         dateCollectionView.register(
             CalendarDateCell.nib,
             forCellWithReuseIdentifier: CalendarDateCell.id
@@ -21,26 +21,6 @@ final class CalendarMonthCell: CoreCollectionViewCell {
 
     func configure(with monthData: CalendarMonthData) {
         setupMonthData(year: monthData.year, month: monthData.month)
-    }
-
-    private func createLayout() -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0 / 7.0),
-            heightDimension: .fractionalWidth(1.0 / 7.0)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalWidth(1.0 / 7.0)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: Array(repeating: item, count: 7)
-        )
-
-        let section = NSCollectionLayoutSection(group: group)
-        return UICollectionViewCompositionalLayout(section: section)
     }
 
     private func setupMonthData(year: Int, month: Int) {

--- a/Health/ViewModels/CalendarViewModel.swift
+++ b/Health/ViewModels/CalendarViewModel.swift
@@ -18,7 +18,15 @@ enum CalendarDataChanges {
 final class CalendarViewModel: ObservableObject {
 
     /// 달력에 표시할 월 데이터 배열 (현재 로드된 모든 월)
-    private var months: [CalendarMonthData] = []
+    @Published private(set) var months: [CalendarMonthData] = []
+
+    /// 데이터 변경 이벤트를 방출하는 AsyncStream
+    private let dataChangesSubject = AsyncStream<CalendarDataChanges>.makeStream()
+
+    /// 데이터 변경 이벤트를 구독할 수 있는 AsyncStream
+    var dataChanges: AsyncStream<CalendarDataChanges> {
+        dataChangesSubject.stream
+    }
 
     /// 상단 로딩중 여부를 나타내는 플래그 (중복 요청 방지)
     private var isLoadingTop = false
@@ -28,9 +36,6 @@ final class CalendarViewModel: ObservableObject {
 
     /// 월 데이터 생성을 담당하는 헬퍼 객체
     private let monthsGenerator = CalendarMonthsGenerator()
-
-    /// 데이터 변경시 뷰 컨트롤러에 알리기 위한 콜백 클로저
-    var onDataChanged: ((CalendarDataChanges) -> Void)?
 
     /// 현재 로드된 월의 총 개수를 반환
     var monthsCount: Int {
@@ -42,13 +47,10 @@ final class CalendarViewModel: ObservableObject {
     }
 
     /// 지정된 인덱스의 월 데이터를 안전하게 반환
-    /// - Parameter index: 배열 인덱스
-    /// - Returns: 해당 인덱스의 월 데이터, 인덱스가 유효하지 않으면 현재 월 반환
-    func month(at index: Int) -> CalendarMonthData {
-        guard index >= 0 && index < months.count else {
-            assertionFailure("Index out of bounds: \(index)")
-            return CalendarMonthData(year: Date().year, month: Date().month)
-        }
+    /// - Parameter index: 배열 인덱스 (0부터 시작)
+    /// - Returns: 해당 인덱스의 월 데이터. 인덱스가 유효하지 않으면 `nil` 반환
+    func month(at index: Int) -> CalendarMonthData? {
+        guard (0..<months.count).contains(index) else { return nil }
         return months[index]
     }
 
@@ -86,7 +88,7 @@ final class CalendarViewModel: ObservableObject {
             IndexPath(item: $0, section: 0)
         }
 
-        onDataChanged?(.topInsert(indexPaths))
+        dataChangesSubject.continuation.yield(.topInsert(indexPaths))
     }
 
     /// 하단에 미래 년도의 월 데이터를 추가로 로드 (무한 스크롤)
@@ -113,7 +115,7 @@ final class CalendarViewModel: ObservableObject {
             IndexPath(item: $0, section: 0)
         }
 
-        onDataChanged?(.bottomInsert(indexPaths))
+        dataChangesSubject.continuation.yield(.bottomInsert(indexPaths))
     }
 }
 


### PR DESCRIPTION
## 작업내용
- 달력의 레이아웃을 생성하는 로직은 CalendarLayoutManager로
  스크롤 관련 로직은 CalendarScrollManager 로 분리했습니다.
- 데이터 변경 감지 콜백 (`onDataChanged`) 을 AsyncStream 으로 교체했습니다.

## 링크
- [노션 태스크](https://www.notion.so/oreumi/Calendar-LayoutManager-ScrollManager-24debaa8982b80d5935fefaea9f2651c?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)