### PR TITLE
chore: 캘린더 탭 달력을 아이패드 가로에서는 3열로 적용, 회전시 스크롤 위치 보정

### DIFF
--- a/Health/Presentation/Calendar/Calendar.storyboard
+++ b/Health/Presentation/Calendar/Calendar.storyboard
@@ -3,8 +3,8 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
-        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -25,18 +25,10 @@
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="icM-Wc-3G9">
-                                        <rect key="frame" x="0.0" y="0.0" width="127.99999999999997" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Jwh-qt-aCM">
-                                            <rect key="frame" x="0.0" y="0.0" width="127.99999999999997" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                             </collectionView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Xqh-mz-GXE"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="2Le-zB-m9C" secondAttribute="bottom" id="2Ql-6p-eNk"/>

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -36,11 +36,7 @@ final class CalendarViewController: CoreGradientViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-
-        coordinator.animate(alongsideTransition: { _ in
-            self.collectionView.collectionViewLayout = CalendarLayoutManager.createMainLayout()
-            self.collectionView.reloadData() // clipping 방지
-        })
+        scrollManager.handleDeviceRotation(coordinator: coordinator)
     }
 }
 

--- a/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
@@ -40,6 +40,26 @@ final class CalendarScrollManager {
         }
     }
 
+    /// 화면 회전 시 스크롤 위치를 처리합니다.
+    func handleDeviceRotation(coordinator: UIViewControllerTransitionCoordinator) {
+        // 회전 전 현재 화면 최상단에 보이는 월을 기억
+        let currentTopMonthIndexPath = findTopMostVisibleIndexPath()
+
+        // 화면 회전과 동시에 레이아웃 변경 및 위치 복원
+        coordinator.animate(alongsideTransition: { context in
+            guard let collectionView = self.collectionView else { return }
+
+            let newLayout = CalendarLayoutManager.createMainLayout()
+            collectionView.setCollectionViewLayout(newLayout, animated: false)
+            collectionView.layoutIfNeeded()
+
+            // 기억해둔 월로 스크롤하여 위치 복원
+            if let indexPath = currentTopMonthIndexPath {
+                collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+            }
+        })
+    }
+
     /// 스크롤 시 무한 스크롤을 처리합니다.
     ///
     /// 상단 또는 하단 임계점에 도달하면 추가 데이터를 비동기로 로드합니다.
@@ -81,5 +101,80 @@ private extension CalendarScrollManager {
             return
         }
         collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+    }
+
+    /// 현재 화면에서 가장 위에 보이는 월의 IndexPath를 찾습니다.
+    ///
+    /// **문제점**: `indexPathsForVisibleItems`가 때로 화면에 보이지 않는 잘못된 셀(예: 0번)을 포함
+    /// **해결책**: 실제 화면 영역과 교집합이 있는 셀만 필터링 후 최상단 선택
+    ///
+    /// - Returns: 화면 최상단 월의 IndexPath, 없으면 nil
+    private func findTopMostVisibleIndexPath() -> IndexPath? {
+        guard let collectionView, let calendarVM else { return nil }
+
+        // 현재 사용자가 보고 있는 화면 영역 계산
+        let currentScreenArea = CGRect(
+            x: 0,
+            y: collectionView.contentOffset.y,
+            width: collectionView.bounds.width,
+            height: collectionView.bounds.height
+        )
+
+        // CollectionView가 제공하는 "보이는 셀" 목록 가져오기
+        // 주의: 이 목록에는 실제로는 화면에 보이지 않는 잘못된 셀이 포함될 수 있음
+        let potentiallyVisibleIndexPaths = collectionView.indexPathsForVisibleItems
+
+        // 실제로 화면에 보이는 유효한 셀들만 걸러내기
+        let actuallyVisibleCells = potentiallyVisibleIndexPaths.compactMap { indexPath -> (IndexPath, CGRect, CalendarMonthData)? in
+
+            // 기본 유효성 검사
+            guard indexPath.item >= 0 && indexPath.item < calendarVM.monthsCount else {
+                // 인덱스가 데이터 범위를 벗어나면 무시
+                return nil
+            }
+            guard let cell = collectionView.cellForItem(at: indexPath) else {
+                // 실제 셀이 존재하지 않으면 무시
+                return nil
+            }
+            guard let monthData = calendarVM.month(at: indexPath.item) else {
+                // 월 데이터가 없으면 무시
+                return nil
+            }
+
+            // 실제 화면에 보이는지 확인
+            let cellFrame = cell.frame
+            let overlappingArea = currentScreenArea.intersection(cellFrame)
+
+            if overlappingArea.isEmpty {
+                // 셀이 화면과 전혀 겹치지 않으면 제외 (예: 0번 셀)
+                return nil
+            }
+
+            // 유효한 셀이므로 포함
+            return (indexPath, cellFrame, monthData)
+        }
+
+        // 유효한 셀들 중에서 화면 최상단에 가장 가까운 셀 찾기
+        let topMostVisibleCell = actuallyVisibleCells.min { cell1, cell2 in
+            // 각 셀이 화면 상단에서 얼마나 떨어져 있는지 계산
+            let distanceFromScreenTop1 = abs(cell1.1.minY - currentScreenArea.minY)
+            let distanceFromScreenTop2 = abs(cell2.1.minY - currentScreenArea.minY)
+
+            // 거리가 더 짧은(화면 상단에 더 가까운) 셀을 선택
+            return distanceFromScreenTop1 < distanceFromScreenTop2
+        }
+
+        // 찾은 셀의 IndexPath 반환
+        if let topCell = topMostVisibleCell {
+            return topCell.0
+        }
+
+        // Fallback - 위 방법이 실패하면 화면 상단 중앙 지점에서 직접 찾기
+        let screenTopCenterPoint = CGPoint(
+            x: currentScreenArea.midX,
+            y: currentScreenArea.minY + 50 // 화면 상단에서 50pt 아래 (여백 고려)
+        )
+
+        return collectionView.indexPathForItem(at: screenTopCenterPoint)
     }
 }


### PR DESCRIPTION
## 작업내용
- 아이패드 가로모드에서는 캘린더 탭 달력을 3열로 적용합니다.
- 경고 메시지 처리를 위해 Calendar.storyboard 의 CollectionView Cell 을 제거합니다.
- 아이패드 회전시 스크롤 위치가 이상한 문제가 있어서, 이전에 보고 있던 월이 상단에 위치하도록 합니다.

## 테스트
| 아이패드 세로 | 아이패드 가로 |
| -- | -- |
| <img width="2064" height="2752" alt="simulator_screenshot_8C7348BD-87D0-4A60-B371-D3255C1E3363" src="https://github.com/user-attachments/assets/cf8f4c2a-1b2f-4358-9287-c1d9c2b8e511" /> | <img width="2752" height="2064" alt="simulator_screenshot_9AFDCF19-686E-424E-89E3-FB81696EE990" src="https://github.com/user-attachments/assets/4b0bdb3f-50a5-4f45-a9d6-fdcdebf462f9" /> |

## 링크
- [노션 태스크](https://www.notion.so/oreumi/3-24debaa8982b80a280a2e070624c612a?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)