### PR TITLE
fix: 아이패드 캘린더 Scroll to Top 시 무한스크롤 중복 동작 문제 수정

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -157,6 +157,6 @@ extension CalendarViewController: UICollectionViewDelegate {
 
     /// 스크롤 시 무한 스크롤 처리 (상단/하단 임계점 도달 시 추가 데이터 로드)
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollManager.scrollViewDidScroll(scrollView)
+        scrollManager.handleScrollForInfiniteLoading(scrollView)
     }
 }


### PR DESCRIPTION
## 작업내용
- 아이패드에서 상태바(Status Bar) 영역을 탭하면 최상단으로 스크롤됩니다. (Scroll to Top)
- 이때 무한스크롤이 중복으로 동작하는 문제를 수정했습니다.

## 링크
- [노션 태스크](https://www.notion.so/oreumi/Scroll-to-Top-24debaa8982b80cbb6c5ead8d237aec5?source=copy_link)