### PR TITLE
feat: `DahsboardViewModel`에서 `denied` 상태도 방출, 대시보드의 일부 셀의 UI 색상 및 제약 수정, 라인 차트가 그려지지 않는 문제 수정

### DIFF
--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -67,7 +67,10 @@ extension AlanActivitySummaryCollectionViewCell {
 
         case .failure:
             summaryLabel.text = nil // TODO: - 네트워크 통신 실패 UI 구성하기
-            print("🔴 Failed to fetch statistics HKData: AlanActivitySummaryCollectionViewCell")
+            print("🔴 건강 데이터를 불러오는 데 실패함: AlanActivitySummaryCollectionViewCell")
+
+        case .denied:
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: AlanActivitySummaryCollectionViewCell")
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -70,6 +70,7 @@ extension AlanActivitySummaryCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: AlanActivitySummaryCollectionViewCell")
 
         case .denied:
+            summaryLabel.text = nil // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: AlanActivitySummaryCollectionViewCell")
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -50,7 +50,7 @@ extension DailyGoalRingCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: DailyGoalRingCell")
 
         case .denied:
-            // TODO: - 예외 UI 로직 구현하기
+            circleProgressView.currentValue = nil
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DailyGoalRingCell")
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -47,7 +47,11 @@ extension DailyGoalRingCollectionViewCell {
 
         case .failure:
             circleProgressView.currentValue = nil
-            print("🔴 Failed to fetch statistics HKData: DailyGoalRingCell")
+            print("🔴 건강 데이터를 불러오는 데 실패함: DailyGoalRingCell")
+
+        case .denied:
+            // TODO: - 예외 UI 로직 구현하기
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DailyGoalRingCell")
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -46,7 +46,7 @@ extension DailyGoalRingCollectionViewCell {
             circleProgressView.currentValue = Double(content.currentStepCount)
 
         case .failure:
-            circleProgressView.currentValue = nil
+            circleProgressView.currentValue = 0
             print("🔴 건강 데이터를 불러오는 데 실패함: DailyGoalRingCell")
 
         case .denied:

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -37,6 +37,18 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
         rangeOfDateLabel.font = .systemFont(ofSize: 13, weight: .semibold)
 
         barChartsView.configuration.displayOptions.showValueLabel = true
+
+        registerForTraitChanges()
+    }
+
+    private func registerForTraitChanges() {
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
+            if self.traitCollection.userInterfaceStyle == .dark {
+                self.chartsContainerView.layer.borderWidth = 0
+            } else {
+                self.chartsContainerView.layer.borderWidth = 1
+            }
+        }
     }
 }
 
@@ -53,6 +65,7 @@ extension DashboardBarChartsCollectionViewCell {
     }
     
     private func render(for state: LoadState<DashboardChartsContents>) {
+        var attrString: NSAttributedString
         headerLabel.text = viewModel.headerTitle
 
         switch state {
@@ -66,9 +79,7 @@ extension DashboardBarChartsCollectionViewCell {
             let count = Double(chartsDatas.count)
             let avgValue = chartsDatas.reduce(0.0, { $0 + $1.value }) / count
             let avgString = avgValue.formatted(.number.precision(.fractionLength(0))) + " 걸음"
-            averageValueLabel.attributedText = NSAttributedString(string: avgString)
-                .font(.preferredFont(forTextStyle: .footnote), to: "걸음")
-                .foregroundColor(.secondaryLabel, to: "걸음")
+            attrString = NSAttributedString(string: avgString)
 
             barChartsView.chartData = prepareChartData(
                 chartsDatas,
@@ -88,13 +99,19 @@ extension DashboardBarChartsCollectionViewCell {
 
 
         case .failure:
-            // TODO: - 예외 UI 로직 구현하기
+            // TODO: - 차트 중앙에 '데이터를 불러올 수 없다'고 표시
+            attrString = NSAttributedString(string: "-")
             print("🔴 건강 데이터를 불러오는 데 실패함: DashboardBarChartsCell (\(viewModel.itemID.kind))")
 
         case .denied:
-            // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
-            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DashboardBarChartsCell")
+            // TODO: - 차트 중앙에 '접근 권한이 없다'고 표시
+            attrString = NSAttributedString(string: "-")
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DashboardBarChartsCell (\(viewModel.itemID.kind))")
         }
+
+        averageValueLabel.attributedText = attrString
+            .font(.preferredFont(forTextStyle: .footnote), to: "걸음")
+            .foregroundColor(.secondaryLabel, to: "걸음")
     }
 
 

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -88,7 +88,11 @@ extension DashboardBarChartsCollectionViewCell {
 
         case .failure:
             // TODO: - 예외 UI 로직 구현하기
-            print("🔴 Failed to fetch HealthKit Datas: DashboardBarChartsCell (\(viewModel.itemID.kind))")
+            print("🔴 건강 데이터를 불러오는 데 실패함: DashboardBarChartsCell (\(viewModel.itemID.kind))")
+
+        case .denied:
+            // TODO: - 예외 UI 로직 구현하기
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DashboardBarChartsCell")
         }
     }
 

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -63,7 +63,8 @@ extension DashboardBarChartsCollectionViewCell {
             return // TODO: - 스켈레톤 UI 코드 구성하기
             
         case let .success(chartsDatas):
-            let avgValue = chartsDatas.reduce(0.0, { $0 + $1.value }) / Double(chartsDatas.count)
+            let count = Double(chartsDatas.count)
+            let avgValue = chartsDatas.reduce(0.0, { $0 + $1.value }) / count
             let avgString = avgValue.formatted(.number.precision(.fractionLength(0))) + " 걸음"
             averageValueLabel.attributedText = NSAttributedString(string: avgString)
                 .font(.preferredFont(forTextStyle: .footnote), to: "걸음")
@@ -91,7 +92,7 @@ extension DashboardBarChartsCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: DashboardBarChartsCell (\(viewModel.itemID.kind))")
 
         case .denied:
-            // TODO: - 예외 UI 로직 구현하기
+            // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DashboardBarChartsCell")
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.xib
@@ -42,17 +42,28 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oNf-dL-Qdx">
                                 <rect key="frame" x="0.0" y="36" width="380" height="319"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Dfg-8a-HVz">
-                                        <rect key="frame" x="16" y="23.999999999999996" width="69.333333333333329" height="39.666666666666657"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Dfg-8a-HVz">
+                                        <rect key="frame" x="16" y="23.999999999999996" width="348" height="39.666666666666657"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="평균" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-UC-OoT">
-                                                <rect key="frame" x="0.0" y="0.0" width="22.666666666666668" height="15.666666666666666"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <color key="textColor" systemColor="secondaryLabelColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,000보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HDS-Bg-WII">
-                                                <rect key="frame" x="0.0" y="15.666666666666671" width="69.333333333333329" height="24"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fsg-d2-zlQ">
+                                                <rect key="frame" x="0.0" y="0.0" width="348" height="15.666666666666666"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="평균" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-UC-OoT">
+                                                        <rect key="frame" x="0.0" y="0.0" width="250.66666666666666" height="15.666666666666666"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="7월 6일~7월 13일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="guh-S2-Af9">
+                                                        <rect key="frame" x="250.66666666666671" y="0.0" width="97.333333333333343" height="15.666666666666666"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HDS-Bg-WII">
+                                                <rect key="frame" x="0.0" y="15.666666666666671" width="348" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -62,12 +73,6 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kqw-NQ-e4v" customClass="BarChartsView" customModule="Health" customModuleProvider="target">
                                         <rect key="frame" x="24" y="79.666666666666671" width="332" height="215.33333333333331"/>
                                     </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="7월 6일~7월 13일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="guh-S2-Af9">
-                                        <rect key="frame" x="266.66666666666669" y="24" width="97.333333333333314" height="15.666666666666664"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <color key="textColor" systemColor="secondaryLabelColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -76,9 +81,8 @@
                                     <constraint firstItem="Dfg-8a-HVz" firstAttribute="leading" secondItem="oNf-dL-Qdx" secondAttribute="leading" constant="16" id="ELu-mp-hNJ"/>
                                     <constraint firstItem="kqw-NQ-e4v" firstAttribute="leading" secondItem="oNf-dL-Qdx" secondAttribute="leading" constant="24" id="EsO-ew-A2j"/>
                                     <constraint firstItem="Dfg-8a-HVz" firstAttribute="top" secondItem="oNf-dL-Qdx" secondAttribute="top" constant="24" id="Fg6-bW-RZs"/>
-                                    <constraint firstAttribute="trailing" secondItem="guh-S2-Af9" secondAttribute="trailing" constant="16" id="NJy-vh-BNM"/>
                                     <constraint firstAttribute="bottom" secondItem="kqw-NQ-e4v" secondAttribute="bottom" constant="24" id="QiE-YK-A0s"/>
-                                    <constraint firstItem="guh-S2-Af9" firstAttribute="top" secondItem="oNf-dL-Qdx" secondAttribute="top" constant="24" id="c9D-xr-w7X"/>
+                                    <constraint firstAttribute="trailing" secondItem="Dfg-8a-HVz" secondAttribute="trailing" constant="16" id="pue-Dr-XjZ"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -118,7 +118,7 @@ extension HealthInfoCardCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoCardCollectionViewCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
 
         case .denied:
-            attrString = NSAttributedString(string: "- " + unitString) // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
+            attrString = NSAttributedString(string: "- " + unitString)
             statusContainerView.isHidden = true
             statusProgressBarView.currentValue = nil
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoCardCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -107,23 +107,23 @@ extension HealthInfoCardCollectionViewCell {
             }()
             
             attrString = NSAttributedString(string: String(format: "%.1f", hkValue) + unitString)
-                .font(.preferredFont(forTextStyle: .footnote), to: unitString)
-                .foregroundColor(.secondaryLabel, to: unitString)
-            
             gaitStatusLabel.text = status.rawValue
             gaitStatusLabel.textColor = status.backgroundColor
             statusContainerView.backgroundColor = status.secondaryBackgroundColor
             
         case .failure:
             attrString = NSAttributedString(string: "- " + unitString)
-                .font(.preferredFont(forTextStyle: .footnote), to: unitString)
-                .foregroundColor(.secondaryLabel, to: unitString)
             statusContainerView.isHidden = true
             statusProgressBarView.currentValue = nil
-            
-            print("🔴 Failed to fetch HealthKit data: HealthInfoCardCollectionViewCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
+            print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoCardCollectionViewCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
+
+        case .denied:
+            attrString = NSAttributedString(string: "- " + unitString)
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoCardCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
         
         valueLabel.attributedText = attrString
+            .font(.preferredFont(forTextStyle: .footnote), to: unitString)
+            .foregroundColor(.secondaryLabel, to: unitString)
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -118,7 +118,9 @@ extension HealthInfoCardCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoCardCollectionViewCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
 
         case .denied:
-            attrString = NSAttributedString(string: "- " + unitString)
+            attrString = NSAttributedString(string: "- " + unitString) // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
+            statusContainerView.isHidden = true
+            statusProgressBarView.currentValue = nil
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoCardCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
         

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
@@ -59,7 +59,7 @@
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="e7A-fc-gRb" secondAttribute="bottom" id="2fo-Td-jAg"/>
                                             <constraint firstAttribute="trailing" secondItem="5ac-L3-PfJ" secondAttribute="trailing" id="2sU-Xo-cu3"/>
-                                            <constraint firstItem="5ac-L3-PfJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="e7A-fc-gRb" secondAttribute="trailing" constant="12" id="ICb-Na-0Yi"/>
+                                            <constraint firstItem="5ac-L3-PfJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="e7A-fc-gRb" secondAttribute="trailing" constant="6" id="ICb-Na-0Yi"/>
                                             <constraint firstItem="e7A-fc-gRb" firstAttribute="leading" secondItem="QNc-SU-0qE" secondAttribute="leading" id="ICq-8q-kYf"/>
                                             <constraint firstItem="e7A-fc-gRb" firstAttribute="top" secondItem="QNc-SU-0qE" secondAttribute="top" id="Kse-ps-SeP"/>
                                             <constraint firstAttribute="height" constant="28" id="X7r-dU-hQc"/>

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -47,7 +47,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowRadius = 5
         self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
 
-        symbolContainerView.backgroundColor = .systemGray6
+        symbolContainerView.backgroundColor = .systemGray5
 
         valueLabel.minimumScaleFactor = 0.5
         valueLabel.adjustsFontSizeToFitWidth = true
@@ -113,7 +113,7 @@ extension HealthInfoStackCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
 
         case .denied:
-            lblString = "-" // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
+            lblString = "-"
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
 

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -16,6 +16,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var symbolImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var valueLabel: UILabel!
+    @IBOutlet weak var unitLabel: UILabel!
     @IBOutlet weak var chartsContainerView: UIView!
 
     private var chartsHostingController: UIHostingController<LineChartsView>?
@@ -84,10 +85,11 @@ extension HealthInfoStackCollectionViewCell {
     }
 
     private func render(_ new: LoadState<InfoStackContent>, parent: UIViewController?) {
-        var attrString: NSAttributedString
+        var lblString: String
         let unitString = viewModel.itemID.kind.unitString
         titleLabel.text = viewModel.itemID.kind.title
         symbolImageView.image = UIImage(systemName: viewModel.itemID.kind.systemName)
+        unitLabel.text = unitString
 
         switch new {
         case .idle:
@@ -97,24 +99,25 @@ extension HealthInfoStackCollectionViewCell {
             return // TODO: - 로딩 시 Skeleton Effect 출력하기
 
         case let .success(content):
-            attrString = NSAttributedString(string: String(format: "%0.f", content.value) + unitString)
+            lblString = String(format: "%0.f", content.value)
 
-            if let charts = content.charts {
-                addChartsHostingController(with: charts, parent: parent)
+            if let charts = content.charts, !charts.isEmpty {
+                if traitCollection.verticalSizeClass == .regular &&
+                    traitCollection.horizontalSizeClass == .regular {
+                    addChartsHostingController(with: charts, parent: parent)
+                }
             }
 
         case .failure:
-            attrString = NSAttributedString(string: "0" + unitString)
+            lblString = "0"
             print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
 
         case .denied:
-            attrString = NSAttributedString(string: "-" + unitString)
-            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoStackCell")
+            lblString = "-" // TODO: - 접근 권한 없을 시, 예외 UI 구성하기
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
 
-        valueLabel.attributedText = attrString
-            .font(.preferredFont(forTextStyle: .footnote), to: unitString)
-            .foregroundColor(.secondaryLabel, to: unitString)
+        valueLabel.text = lblString
     }
 
     private func addChartsHostingController(
@@ -122,7 +125,8 @@ extension HealthInfoStackCollectionViewCell {
         parent: UIViewController?
     ) {
         // TOOD: - LineCharts가 범용 데이터를 받도록 코드 리팩토링하기
-        let hkd = charts.map { HKData(startDate: $0.date, endDate: $0.date, value: $0.value) }
+        let sliced = Array(charts.prefix(7))
+        let hkd = sliced.map { HKData(startDate: $0.date, endDate: $0.date, value: $0.value) }
         let hVC = LineChartsHostingController(chartsData: hkd)
         parent?.addChild(hVC, to: chartsContainerView)
         self.chartsHostingController = hVC

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -98,8 +98,6 @@ extension HealthInfoStackCollectionViewCell {
 
         case let .success(content):
             attrString = NSAttributedString(string: String(format: "%0.f", content.value) + unitString)
-                .font(.preferredFont(forTextStyle: .footnote), to: unitString)
-                .foregroundColor(.secondaryLabel, to: unitString)
 
             if let charts = content.charts {
                 addChartsHostingController(with: charts, parent: parent)
@@ -107,13 +105,16 @@ extension HealthInfoStackCollectionViewCell {
 
         case .failure:
             attrString = NSAttributedString(string: "0" + unitString)
-                .font(.preferredFont(forTextStyle: .footnote), to: unitString)
-                .foregroundColor(.secondaryLabel, to: unitString)
+            print("🔴 건강 데이터를 불러오는 데 실패함: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
 
-            print("🔴 Failed to fetch HealthKit data: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
+        case .denied:
+            attrString = NSAttributedString(string: "-" + unitString)
+            print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoStackCell")
         }
 
         valueLabel.attributedText = attrString
+            .font(.preferredFont(forTextStyle: .footnote), to: unitString)
+            .foregroundColor(.secondaryLabel, to: unitString)
     }
 
     private func addChartsHostingController(

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.xib
@@ -46,12 +46,23 @@
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="1,000보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HHU-P7-rxf">
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="eii-ac-pM5">
                                         <rect key="frame" x="0.0" y="13.333333333333334" width="122" height="20.333333333333329"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="751" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HHU-P7-rxf">
+                                                <rect key="frame" x="0.0" y="0.0" width="10.333333333333334" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kcal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TNg-P7-QJj">
+                                                <rect key="frame" x="10.333333333333336" y="3.9999999999999956" width="111.66666666666666" height="15.666666666666664"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DDj-vA-Ec4">
@@ -86,6 +97,7 @@
                 <outlet property="symbolContainerView" destination="qVC-yD-eOe" id="O2X-Xw-Akx"/>
                 <outlet property="symbolImageView" destination="hCH-M6-aWc" id="xfg-Zd-Ibw"/>
                 <outlet property="titleLabel" destination="lCs-nZ-F1Q" id="btX-cV-8pM"/>
+                <outlet property="unitLabel" destination="TNg-P7-QJj" id="gAf-Iv-36r"/>
                 <outlet property="valueLabel" destination="HHU-P7-rxf" id="1Cy-xx-MRl"/>
             </connections>
             <point key="canvasLocation" x="329.7709923664122" y="24.647887323943664"/>
@@ -93,7 +105,7 @@
     </objects>
     <resources>
         <namedColor name="boxBgColor">
-            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.95294117647058818" green="0.95294117647058818" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Health/Services/HealthService/MockHealthService.swift
+++ b/Health/Services/HealthService/MockHealthService.swift
@@ -99,7 +99,7 @@ final class MockHealthService: HealthService {
     ) async throws -> HKData {
         let date = Date.now
         let (startDay, endDay) = date.rangeOfDay()
-        return HKData(startDate: startDay, endDate: endDay, value: 123.45)
+        return HKData(startDate: startDay, endDate: endDay, value: 1.4)
     }
 
     func fetchStatistics(

--- a/Health/ViewModels/Cells/HealthInfoStackCellViewModel.swift
+++ b/Health/ViewModels/Cells/HealthInfoStackCellViewModel.swift
@@ -23,7 +23,7 @@ final class HealthInfoStackCellViewModel {
     ///
     struct Content: Hashable {
         let value: Double
-        let charts: [Charts]? = nil
+        let charts: [Charts]?
 
         struct Charts: Hashable {
             let date: Date
@@ -32,6 +32,7 @@ final class HealthInfoStackCellViewModel {
 
         init(value: Double, charts: [Charts]? = nil) {
             self.value = value
+            self.charts = charts
         }
     }
 

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -201,8 +201,8 @@ extension DashboardViewModel {
                     continue
                 }
 
-                // 지난 7일 간 라인 차트를 그리기 위해 7일 전 시간 구하기
-                guard let startDate: Date = anchorDate.endOfDay().addingDays(-7) else {
+                // 지난 7일 간 라인 차트를 그리기 위해 30일 전 시간 구하기
+                guard let startDate: Date = anchorDate.endOfDay().addingDays(-365) else {
                     vm.setState(.failure(nil))
                     continue
                 }

--- a/Health/ViewModels/Dashboard/Enum/LoadState.swift
+++ b/Health/ViewModels/Dashboard/Enum/LoadState.swift
@@ -15,7 +15,9 @@ enum LoadState<Value> where Value: Equatable {
     ///
     case success(Value)
     ///
-    case failure(Error)
+    case failure(Error?)
+    ///
+    case denied
 }
 
 extension LoadState: Equatable {
@@ -27,6 +29,8 @@ extension LoadState: Equatable {
         case (let .success(value1), let .success(value2)):
             return value1 == value2
         case (.failure, .failure):
+            return true
+        case (.denied, .denied):
             return true
         default:
             return false


### PR DESCRIPTION
[Notion Task](https://www.notion.so/oreumi/UI-24eebaa8982b80bc8efae3605a414273?source=copy_link)

---

## ✅ 변경사항

- `LoadState`가 (권한 없음을 의미하는) `denied`도 가지도록 코드를 수정하였습니다.
- `DashboardViewModel`에서 각 셀의 뷰-모델에 `denied` 상태도 전달하도록 코드를 개선하였습니다. (`데이터 가져오기 실패`와 `권한 없음` 상태를 보다 엄격히 구분)
- 아이패드 환경에서 `걸은 거리` 셀 옆에 라인 차트가 그려지지 않는 문제를 수정하였습니다.
- 대시보드 상단의 `걸은 거리`, `운동 시간` 셀의 심볼 원형 배경 색상을 `systemGray5`로 수정하였습니다. (`systemGray6`는 라이트 모드에서 안보임)
- 대시보드 중간의 `막대 그래프`에 borderWidth가 제대로 적용되지 않는 문제를 수정하였습니다.

---

## 📝 참고

- 이번 PR도 마찬가지로, PR이 너무 커질 것이 우려되어 한번 끊고자 올리게 되었습니다. 
- **다음 PR부터 (내일부터) `막대 그래프`, `보행 속도`, `보행 보폭` 셀에 대하여 예외 UI를 하나씩 구현할 계획입니다.** @giseungNoh 
 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="1179" height="2556" alt="IMG_0448" src="https://github.com/user-attachments/assets/afdd0a98-ac7a-4f69-a676-d438be360c19" />  |  <img width="1179" height="2556" alt="IMG_0449" src="https://github.com/user-attachments/assets/fcf2d512-d8a6-4fb6-be9f-1ba18befa42c" />   |

* UI와 기능이 달라진 건 없습니다. 다음 작업을 위한 준비 준비 작업일 뿐...

---

