### PR TITLE
feat: Profile 건강 데이터 권한 핸들링

### DIFF
--- a/Health/Core/Storage/UserDefaults/UserDefaultsKeys.swift
+++ b/Health/Core/Storage/UserDefaults/UserDefaultsKeys.swift
@@ -18,4 +18,11 @@ extension UserDefaultsKeys {
             defaultValue: false
         )
     }
+    
+    var healthkitLinked: UserDefaultsKey<Bool> {
+        UserDefaultsKey<Bool>(
+            "HealthKitLinked",
+            defaultValue: false
+        )
+    }
 }

--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -19,7 +19,7 @@ class ProfileViewController: CoreGradientViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
-    private let healthService = DefaultHealthService()
+    @Injected private var healthService: HealthService
     
     private var grantRecheckObserver: NSObjectProtocol?
     
@@ -79,6 +79,10 @@ class ProfileViewController: CoreGradientViewController {
         super.viewWillDisappear(animated)
         stopForegroundGrantSync()
     }
+    
+    deinit {
+        stopForegroundGrantSync()
+    }
         
     /// 앱이 포어그라운드로 복귀할 때마다 HealthKit 권한을 재확인하도록 옵저버를 등록합니다.
     ///
@@ -101,7 +105,6 @@ class ProfileViewController: CoreGradientViewController {
     /// 포어그라운드 권한 확인하는 옵저버를 제거합니다.
     ///
     /// - Note: 옵저버가 중복 등록되지 않도록 옵저버를 등록하기 전에 호출합니다.
-    @MainActor
     private func stopForegroundGrantSync() {
         if let obs = grantRecheckObserver {
             NotificationCenter.default.removeObserver(obs)
@@ -174,7 +177,7 @@ class ProfileViewController: CoreGradientViewController {
             grantRecheckObserver = nil
         }
         
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self = self else { return }
             let hasAny = await self.healthService.checkHasAnyReadPermission()
             
@@ -220,7 +223,6 @@ class ProfileViewController: CoreGradientViewController {
         })
         
         present(alert, animated: true)
-        print(UserDefaultsWrapper.shared.healthkitLinked)
     }
     
     private func presentDenyAlert(for sender: UISwitch) {
@@ -254,7 +256,6 @@ class ProfileViewController: CoreGradientViewController {
         })
         
         present(alert, animated: true)
-        print(UserDefaultsWrapper.shared.healthkitLinked)
 
     }
     

--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -12,12 +12,16 @@ struct ProfileCellModel {
     let title: String
     let iconName: String
     let isSwitch: Bool
-    var switchState: Bool = false
+    var switchState: Bool = UserDefaultsWrapper.shared.healthkitLinked
 }
 
 class ProfileViewController: CoreGradientViewController {
-        
+    
     @IBOutlet weak var tableView: UITableView!
+    
+    private let healthService = DefaultHealthService()
+    
+    private var grantRecheckObserver: NSObjectProtocol?
     
     private let sectionTitles: [String?] = [
         nil,
@@ -47,7 +51,7 @@ class ProfileViewController: CoreGradientViewController {
             title: "Apple 건강 앱",
             iconName: "applelogo",
             isSwitch: true,
-            switchState: true
+            switchState: UserDefaultsWrapper.shared.healthkitLinked
         )
         ]
     ]
@@ -66,11 +70,209 @@ class ProfileViewController: CoreGradientViewController {
         tableView.backgroundColor = .clear
     }
     
-    @objc private func switchChanged(_ sender: UISwitch) {
-        print("Apple 건강 앱 권한 상태:", sender.isOn)
-        sectionItems[sender.tag][0].switchState = sender.isOn
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        startForegroundGrantSync()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopForegroundGrantSync()
+    }
+        
+    /// 앱이 포어그라운드로 복귀할 때마다 HealthKit 권한을 재확인하도록 옵저버를 등록합니다.
+    ///
+    /// - Important: Swift 6 기준 `MainActor` 격리를 위해 클로저 내부에서 `Task { @MainActor in ... }`로 hop 합니다.
+    @MainActor
+    private func startForegroundGrantSync() {
+        stopForegroundGrantSync()
+        
+        grantRecheckObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.recheckGrantAndSave()
+            }
+        }
+    }
+    
+    /// 포어그라운드 권한 확인하는 옵저버를 제거합니다.
+    ///
+    /// - Note: 옵저버가 중복 등록되지 않도록 옵저버를 등록하기 전에 호출합니다.
+    @MainActor
+    private func stopForegroundGrantSync() {
+        if let obs = grantRecheckObserver {
+            NotificationCenter.default.removeObserver(obs)
+            grantRecheckObserver = nil
+        }
+    }
+    
+    /// 현재 HealthKit 읽기 권한을 비동기로 재확인하고, UI/모델/저장을 동기화합니다.
+    @MainActor
+    private func recheckGrantAndSave() async {
+        let hasAny = await healthService.checkHasAnyReadPermission()
+        UserDefaultsWrapper.shared.healthkitLinked = hasAny
+        updateSectionItemsForHealthSwitch(to: hasAny)
+    }
+    
+    /// 테이블 셀 내 스위치 값 변경 이벤트를 처리합니다.
+    ///
+    /// - Parameter sender: `UISwitch`
+    @objc private func switchChanged(_ sender: UISwitch) {
+        // ON: 권한 요청
+        if sender.isOn {
+            Task { [weak self] in
+                guard let self = self else { return }
+                do {
+                    let granted = try await self.healthService.requestAuthorization()
+                    await MainActor.run {
+                        if granted {
+                            // 정상적으로 하나 이상 허용됨
+                            UserDefaultsWrapper.shared.healthkitLinked = true
+                            self.updateSectionItemsForHealthSwitch(to: true)
+                        } else {
+                            // 권한이 하나도 없을 때: 권한 허용 얼럿 표시
+                            self.presentGrantAlert(for: sender)
+                        }
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.presentGrantAlert(for: sender)
+                    }
+                }
+            }
+        } else { // OFF
+            presentDenyAlert(for: sender)
+        }
+    }
+    
+    private func startGrantRecheckAfterReturning(switch sender: UISwitch) {
+        // 기존 옵저버 제거
+        if let obs = grantRecheckObserver {
+            NotificationCenter.default.removeObserver(obs)
+            grantRecheckObserver = nil
+        }
+        
+        grantRecheckObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            Task { @MainActor in
+                self.recheckGrantAndSyncSwitch(sender)
+            }
+        }
+    }
+    
+    @MainActor
+    private func recheckGrantAndSyncSwitch(_ sender: UISwitch) {
+        if let obs = grantRecheckObserver {
+            NotificationCenter.default.removeObserver(obs)
+            grantRecheckObserver = nil
+        }
+        
+        Task { [weak self] in
+            guard let self = self else { return }
+            let hasAny = await self.healthService.checkHasAnyReadPermission()
+            
+            // 권한이 하나라도 남아있으면 ON, 아니면 OFF 유지
+            if hasAny {
+                sender.setOn(true, animated: true)
+                UserDefaultsWrapper.shared.healthkitLinked = true
+                self.updateSectionItemsForHealthSwitch(to: true)
+            } else {
+                sender.setOn(false, animated: true)
+                UserDefaultsWrapper.shared.healthkitLinked = false
+                self.updateSectionItemsForHealthSwitch(to: false)
+            }
+        }
+    }
+    
+    @MainActor
+    private func presentGrantAlert(for sender: UISwitch) {
+        let alert = UIAlertController(
+            title: "권한 허용을 위해 건강앱으로 이동합니다.",
+            message: """
+    건강 앱에서 다음 경로로 이동하세요:
+    
+    우측 상단 프로필 ▸ 개인정보 보호 ▸ 앱 ▸ Health 
+    (해당 화면에서 이 앱의 데이터 접근 권한을 변경할 수 있어요)
+    """,
+            preferredStyle: .alert
+        )
+        
+        // 취소: 사용자가 거부 의사 → OFF
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
+            guard let self = self else { return }
+            sender.setOn(false, animated: true)
+            UserDefaultsWrapper.shared.healthkitLinked = false
+            self.updateSectionItemsForHealthSwitch(to: false)
+        })
+        
+        // 열기: 건강앱 열어주고 돌아오면 권한 재확인
+        alert.addAction(UIAlertAction(title: "열기", style: .default) { [weak self] _ in
+            guard let self = self else { return }
+            self.openHealthApp()
+            self.startGrantRecheckAfterReturning(switch: sender)
+        })
+        
+        present(alert, animated: true)
+        print(UserDefaultsWrapper.shared.healthkitLinked)
+    }
+    
+    private func presentDenyAlert(for sender: UISwitch) {
+        let alert = UIAlertController(
+            title: "권한 해제를 위해 건강앱으로 이동합니다",
+            message: """
+    건강 앱에서 다음 경로로 이동하세요:
+    
+    우측 상단 프로필 ▸ 개인정보 보호 ▸ 앱 ▸ Health 
+    (해당 화면에서 이 앱의 데이터 접근 권한을 변경할 수 있어요)
+    """,
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
+            guard let self = self else { return }
+            // 취소: 스위치 복구
+            sender.setOn(true, animated: true)
+            UserDefaultsWrapper.shared.healthkitLinked = true
+            self.updateSectionItemsForHealthSwitch(to: true)
+        })
+        
+        alert.addAction(UIAlertAction(title: "열기", style: .default) { [weak self] _ in
+            guard let self = self else { return }
+            
+            // 건강 앱 열기
+            self.openHealthApp()
+            
+            // 설정에서 돌아오면 권한을 재확인해 스위치 상태 동기화
+            self.startGrantRecheckAfterReturning(switch: sender)
+        })
+        
+        present(alert, animated: true)
+        print(UserDefaultsWrapper.shared.healthkitLinked)
+
+    }
+    
+    /// 건강(Health) 앱을 엽니다.
+    ///
+    /// - Note: 사용자가 Health 앱에서 권한을 직접 변경할 수 있도록 유도합니다.
+    private func openHealthApp() {
+        let healthURL = URL(string: "x-apple-health://")!
+        UIApplication.shared.open(healthURL, options: [:])
+    }
+    
+    private func updateSectionItemsForHealthSwitch(to newValue: Bool) {
+        for section in sectionItems.indices {
+            for row in sectionItems[section].indices where sectionItems[section][row].isSwitch {
+                sectionItems[section][row].switchState = newValue
+            }
+        }
+    }
 }
 
 extension ProfileViewController: UITableViewDataSource {


### PR DESCRIPTION

## ✅ 변경사항

- 설정에서 건강앱에서 데이터를 불러오는것에 대한 권한 

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지
![ezgif-48441dfbb8c250](https://github.com/user-attachments/assets/6e9e31eb-552b-40d8-bee3-c6a7de2c260b)

---

### 💜 결과

- 권한 변경을 위해 건강앱으로 연결해줍니다.
- Foreground 진입마다 권한을 확인해서 Switch를 설정하고 UserDefaults에 저장합니다.
- 권한이 하나라도 있을시 On, 하나도 없을시 Off

 
