### PR TITLE
feat: 대시보드의 각 셀에서 `접근 권한 없음` 뷰를 띄우도록 코드 작성

### DIFF
--- a/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
+++ b/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class PermissionDeniedCompactView: UIView {
 
-    /// 'tapped' 알림 이름을 정의하여 탭 이벤트 발생 시 사용합니다.
     static let shouldPresentAlert = Notification.Name("shouldPresentAlert")
 
     private let imageView = UIImageView()

--- a/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
+++ b/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
@@ -12,8 +12,6 @@ final class PermissionDeniedCompactView: UIView {
     static let shouldPresentAlert = Notification.Name("shouldPresentAlert")
 
     private let imageView = UIImageView()
-    private let titleLabel = UILabel()
-    private let contentStackView = UIStackView()
     private let containerView = UIView()
     private let button = UIButton()
 
@@ -45,30 +43,19 @@ final class PermissionDeniedCompactView: UIView {
         backgroundColor = .clear
 
         imageView.image = exclamationMarkImage
-        contentStackView.addArrangedSubview(imageView)
-
-        titleLabel.text = "접근 권한 없음"
-        titleLabel.font = .systemFont(ofSize: 11, weight: .black)
-        titleLabel.textColor = .systemYellow
-        contentStackView.addArrangedSubview(titleLabel)
-
-        contentStackView.spacing = 4
-        contentStackView.alignment = .center
-        containerView.addSubview(contentStackView)
-        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(imageView)
         NSLayoutConstraint.activate([
-            contentStackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 6),
-            contentStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 6),
-            contentStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -6),
-            contentStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -6),
+            imageView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
         ])
 
         containerView.backgroundColor = .systemYellow.withAlphaComponent(0.1)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)
         NSLayoutConstraint.activate([
-            containerView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            containerView.centerYAnchor.constraint(equalTo: centerYAnchor)
+            containerView.heightAnchor.constraint(equalTo: heightAnchor),
+            containerView.widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
         ])
 
         containerView.addSubview(button)

--- a/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
+++ b/Health/Core/Views/PermissionDeniedView/PermissionDeniedCompactView.swift
@@ -37,6 +37,9 @@ final class PermissionDeniedCompactView: UIView {
         super.layoutSubviews()
         containerView.applyCornerStyle(.circular)
         imageView.image = exclamationMarkImage(symbomPointSize)
+        
+        containerView.backgroundColor = traitCollection.userInterfaceStyle == .dark
+        ? .systemYellow.withAlphaComponent(0.15) : .systemYellow.withAlphaComponent(0.3)
     }
 
     private func commonInit() {
@@ -51,7 +54,7 @@ final class PermissionDeniedCompactView: UIView {
         ])
 
         containerView.backgroundColor = traitCollection.userInterfaceStyle == .dark
-        ? .systemYellow.withAlphaComponent(0.1) : .systemYellow.withAlphaComponent(0.3)
+        ? .systemYellow.withAlphaComponent(0.15) : .systemYellow.withAlphaComponent(0.3)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)
         NSLayoutConstraint.activate([
@@ -80,7 +83,7 @@ final class PermissionDeniedCompactView: UIView {
     private func registerForTraitChanges() {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
             if self.traitCollection.userInterfaceStyle == .dark {
-                self.containerView.backgroundColor = .systemYellow.withAlphaComponent(0.1)
+                self.containerView.backgroundColor = .systemYellow.withAlphaComponent(0.15)
             } else {
                 self.containerView.backgroundColor = .systemYellow.withAlphaComponent(0.3)
             }

--- a/Health/Core/Views/PermissionDeniedView/PermissionDeniedFullView.swift
+++ b/Health/Core/Views/PermissionDeniedView/PermissionDeniedFullView.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class PermissionDeniedFullView: UIView {
 
-    /// 'tapped' 알림 이름을 정의하여 탭 이벤트 발생 시 사용합니다.
     static let shouldPresentAlert = Notification.Name("shouldPresentAlert")
 
     private let imageContainerView = UIView()
@@ -118,9 +117,4 @@ final class PermissionDeniedFullView: UIView {
         touchHandler?()
         NotificationCenter.default.post(name: Self.shouldPresentAlert, object: nil)
     }
-}
-
-
-#Preview {
-    PermissionDeniedFullView()
 }

--- a/Health/Core/Views/PermissionDeniedView/PermissionDeniedFullView.swift
+++ b/Health/Core/Views/PermissionDeniedView/PermissionDeniedFullView.swift
@@ -47,12 +47,16 @@ final class PermissionDeniedFullView: UIView {
 
         titleContainerView.layer.cornerCurve = .continuous
         titleContainerView.applyCornerStyle(.circular)
+
+        imageContainerView.backgroundColor = traitCollection.userInterfaceStyle == .dark
+        ? .systemYellow.withAlphaComponent(0.15) : .systemYellow.withAlphaComponent(0.3)
     }
 
     private func commonInit() {
         backgroundColor = .clear
 
-        imageContainerView.backgroundColor = .systemYellow.withAlphaComponent(0.15)
+        imageContainerView.backgroundColor = traitCollection.userInterfaceStyle == .dark
+        ? .systemYellow.withAlphaComponent(0.15) : .systemYellow.withAlphaComponent(0.3)
         imageContainerView.layer.cornerRadius = imageContainerView.frame.width / 2
         imageContainerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -111,9 +115,21 @@ final class PermissionDeniedFullView: UIView {
         ])
 
         addBlurEffect(.systemChromeMaterial)
+
+        registerForTraitChanges()
     }
 
-    @objc func handleButtonTap() {
+    private func registerForTraitChanges() {
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
+            if self.traitCollection.userInterfaceStyle == .dark {
+                self.imageContainerView.backgroundColor = .systemYellow.withAlphaComponent(0.15)
+            } else {
+                self.imageContainerView.backgroundColor = .systemYellow.withAlphaComponent(0.3)
+            }
+        }
+    }
+
+    @objc private func handleButtonTap() {
         touchHandler?()
         NotificationCenter.default.post(name: Self.shouldPresentAlert, object: nil)
     }

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -53,6 +53,7 @@ extension AlanActivitySummaryCollectionViewCell {
             .store(in: &cancellables)
     }
 
+    // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(for state: LoadState<AlanContent>) {
         switch state {
         case .idle:

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -17,13 +17,12 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
     private var viewModel: AlanActivitySummaryCellViewModel!
 
     override func setupAttribute() {
-//       self.applyCornerStyle(.medium)
         self.backgroundColor = .boxBg
-        self.layer.cornerRadius = 12 // medium
+        self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
         self.layer.borderColor = UIColor.separator.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
-        self.layer.shadowOpacity = 0.05
+        self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
         self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -33,6 +33,7 @@ extension DailyGoalRingCollectionViewCell {
             .store(in: &cancalleable)
     }
 
+    // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(for state: LoadState<GoalRingContent>) {
         switch state {
         case .idle:

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 final class DailyGoalRingCollectionViewCell: CoreCollectionViewCell {
 
     @IBOutlet weak var circleProgressView: CircleProgressView!
+    @IBOutlet weak var permissionDeniedView: PermissionDeniedCompactView!
 
     private var cancalleable: Set<AnyCancellable> = []
 
@@ -18,6 +19,10 @@ final class DailyGoalRingCollectionViewCell: CoreCollectionViewCell {
 
     override func prepareForReuse() {
         cancalleable.removeAll()
+    }
+
+    override func setupAttribute() {
+        permissionDeniedView.isHidden = true
     }
 }
 
@@ -35,6 +40,8 @@ extension DailyGoalRingCollectionViewCell {
 
     // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(for state: LoadState<GoalRingContent>) {
+        permissionDeniedView.isHidden = true
+
         switch state {
         case .idle:
             return // TODO: - 플레이스 홀더 UI 구성하기
@@ -51,6 +58,7 @@ extension DailyGoalRingCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: DailyGoalRingCell")
 
         case .denied:
+            permissionDeniedView.isHidden = false
             circleProgressView.currentValue = nil
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DailyGoalRingCell")
         }

--- a/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/DailyGoalRingCollectionViewCell.xib
@@ -16,6 +16,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="376" height="211"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Du8-dP-xaE" customClass="PermissionDeniedCompactView" customModule="Health" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="26" height="26"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="26" id="1i3-Ja-okr"/>
+                            <constraint firstAttribute="height" constant="26" id="qPY-Eb-pO1"/>
+                        </constraints>
+                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aoa-18-szu" customClass="CircleProgressView" customModule="Health" customModuleProvider="target">
                         <rect key="frame" x="8" y="8" width="360" height="195"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -26,11 +34,14 @@
                 <constraint firstAttribute="bottom" secondItem="aoa-18-szu" secondAttribute="bottom" constant="8" id="5aL-QR-U1z"/>
                 <constraint firstAttribute="trailing" secondItem="aoa-18-szu" secondAttribute="trailing" constant="8" id="6J2-Nd-8Fc"/>
                 <constraint firstItem="aoa-18-szu" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="8" id="eSk-MV-TT2"/>
+                <constraint firstItem="Du8-dP-xaE" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="jB1-bc-oA3"/>
+                <constraint firstItem="Du8-dP-xaE" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="oUy-ra-frD"/>
                 <constraint firstItem="aoa-18-szu" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="8" id="vWJ-p4-pro"/>
             </constraints>
             <size key="customSize" width="376" height="211"/>
             <connections>
                 <outlet property="circleProgressView" destination="aoa-18-szu" id="rDH-X5-bjZ"/>
+                <outlet property="permissionDeniedView" destination="Du8-dP-xaE" id="40Y-YD-31x"/>
             </connections>
             <point key="canvasLocation" x="285.49618320610688" y="77.112676056338032"/>
         </collectionViewCell>

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -22,13 +22,12 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
     private var cancellable: Set<AnyCancellable> = []
 
     override func setupAttribute() {
-//       self.applyCornerStyle(.medium)
+        chartsContainerView.applyCornerStyle(.medium)
         chartsContainerView.backgroundColor = .boxBg
-        chartsContainerView.layer.cornerRadius = 12 // medium
         chartsContainerView.layer.masksToBounds = false
         chartsContainerView.layer.borderColor = UIColor.separator.cgColor
         chartsContainerView.layer.shadowColor = UIColor.black.cgColor
-        chartsContainerView.layer.shadowOpacity = 0.05
+        chartsContainerView.layer.shadowOpacity = 0.15
         chartsContainerView.layer.shadowOffset = CGSize(width: 2, height: 2)
         chartsContainerView.layer.shadowRadius = 5
         chartsContainerView.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -16,6 +16,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var chartsContainerView: UIView!
     @IBOutlet weak var rangeOfDateLabel: UILabel!
     @IBOutlet weak var barChartsView: BarChartsView!
+    @IBOutlet weak var permissionDeniedView: PermissionDeniedFullView!
 
     private var viewModel: DashboardBarChartsCellViewModel!
     
@@ -34,6 +35,9 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
 
         averageTitleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         rangeOfDateLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+
+        permissionDeniedView.isHidden = true
+        permissionDeniedView.applyCornerStyle(.medium)
 
         barChartsView.configuration.displayOptions.showValueLabel = true
 
@@ -62,10 +66,12 @@ extension DashboardBarChartsCollectionViewCell {
             .sink { [weak self] state in self?.render(for: state) }
             .store(in: &cancellable)
     }
-    
+
+    // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(for state: LoadState<DashboardChartsContents>) {
         var attrString: NSAttributedString
         headerLabel.text = viewModel.headerTitle
+        permissionDeniedView.isHidden = true
 
         switch state {
         case .idle:
@@ -103,8 +109,12 @@ extension DashboardBarChartsCollectionViewCell {
             print("🔴 건강 데이터를 불러오는 데 실패함: DashboardBarChartsCell (\(viewModel.itemID.kind))")
 
         case .denied:
-            // TODO: - 차트 중앙에 '접근 권한이 없다'고 표시
-            attrString = NSAttributedString(string: "-")
+            attrString = NSAttributedString(string: "12345 걸음")
+            permissionDeniedView.isHidden = false
+            barChartsView.chartData = prepareChartData(
+                Self.chartsDataMock,
+                type: viewModel.itemID.kind
+            )
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: DashboardBarChartsCell (\(viewModel.itemID.kind))")
         }
 
@@ -138,10 +148,6 @@ extension DashboardBarChartsCollectionViewCell {
         let isYearDiff = !startDate.isEqual([.year], with: endDate)
         let isMonthDiff = !startDate.isEqual([.month], with: endDate)
 
-        // 서로 년도가 다른 경우
-        // 년도는 동일 / 월만 다른 경우
-        // 월까지 모두 같은 경우
-
         if case .daysBack = viewModel.itemID.kind {
             var fStartDate: String
             var fEndDate: String
@@ -170,6 +176,18 @@ extension DashboardBarChartsCollectionViewCell {
             return "\(fStartDate)~\(fEndDate)"
         }
     }
+}
+
+fileprivate extension DashboardBarChartsCollectionViewCell {
+
+    static let chartsDataMock: [DashboardChartsContent] = [
+        .init(date: .now, value: Double.random(in: 100...300)),
+        .init(date: .now, value: Double.random(in: 100...300)),
+        .init(date: .now, value: Double.random(in: 100...300)),
+        .init(date: .now, value: Double.random(in: 100...300)),
+        .init(date: .now, value: Double.random(in: 100...300)),
+        .init(date: .now, value: Double.random(in: 100...300))
+    ]
 }
 
 fileprivate extension Double {

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.xib
@@ -73,6 +73,9 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kqw-NQ-e4v" customClass="BarChartsView" customModule="Health" customModuleProvider="target">
                                         <rect key="frame" x="24" y="79.666666666666671" width="332" height="215.33333333333331"/>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="32d-82-oql" customClass="PermissionDeniedFullView" customModule="Health" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="380" height="319"/>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -81,8 +84,12 @@
                                     <constraint firstItem="Dfg-8a-HVz" firstAttribute="leading" secondItem="oNf-dL-Qdx" secondAttribute="leading" constant="16" id="ELu-mp-hNJ"/>
                                     <constraint firstItem="kqw-NQ-e4v" firstAttribute="leading" secondItem="oNf-dL-Qdx" secondAttribute="leading" constant="24" id="EsO-ew-A2j"/>
                                     <constraint firstItem="Dfg-8a-HVz" firstAttribute="top" secondItem="oNf-dL-Qdx" secondAttribute="top" constant="24" id="Fg6-bW-RZs"/>
+                                    <constraint firstItem="32d-82-oql" firstAttribute="leading" secondItem="oNf-dL-Qdx" secondAttribute="leading" id="Iai-Yv-4et"/>
+                                    <constraint firstAttribute="trailing" secondItem="32d-82-oql" secondAttribute="trailing" id="OKC-wB-FxZ"/>
                                     <constraint firstAttribute="bottom" secondItem="kqw-NQ-e4v" secondAttribute="bottom" constant="24" id="QiE-YK-A0s"/>
+                                    <constraint firstAttribute="bottom" secondItem="32d-82-oql" secondAttribute="bottom" id="c2e-Za-Txc"/>
                                     <constraint firstAttribute="trailing" secondItem="Dfg-8a-HVz" secondAttribute="trailing" constant="16" id="pue-Dr-XjZ"/>
+                                    <constraint firstItem="32d-82-oql" firstAttribute="top" secondItem="oNf-dL-Qdx" secondAttribute="top" id="t81-sV-esj"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -102,6 +109,7 @@
                 <outlet property="barChartsView" destination="kqw-NQ-e4v" id="YpG-jO-eYk"/>
                 <outlet property="chartsContainerView" destination="oNf-dL-Qdx" id="TM4-NV-Acz"/>
                 <outlet property="headerLabel" destination="gF7-hX-V0L" id="IXC-m7-PeZ"/>
+                <outlet property="permissionDeniedView" destination="32d-82-oql" id="DMB-zX-vOS"/>
                 <outlet property="rangeOfDateLabel" destination="guh-S2-Af9" id="U4u-VL-yUR"/>
             </connections>
             <point key="canvasLocation" x="390.83969465648852" y="104.5774647887324"/>

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -81,6 +81,7 @@ extension HealthInfoCardCollectionViewCell {
         titleLabel.text = viewModel.itemID.kind.title
         statusProgressBarView.higherIsBetter = viewModel.itemID.kind.higherIsBetter
         statusProgressBarView.thresholdsValues = viewModel.itemID.kind.thresholdValues(age: viewModel.anchorAge)
+        statusContainerView.isHidden = false
         permissionDeniedView.isHidden = true
 
         switch state {

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -15,7 +15,8 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var statusContainerView: UIView!
     @IBOutlet weak var gaitStatusLabel: UILabel!
     @IBOutlet weak var statusProgressBarView: StatusProgressBarView!
-    
+    @IBOutlet weak var permissionDeniedView: PermissionDeniedFullView!
+
     private var viewModel: HealthInfoCardCellViewModel!
 
     private var cancellable: Set<AnyCancellable> = []
@@ -31,18 +32,20 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
     }
     
     override func setupAttribute() {
-//       self.applyCornerStyle(.medium)
         self.backgroundColor = .boxBg
-        self.layer.cornerRadius = 12 // medium
+        self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
         self.layer.borderColor = UIColor.separator.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
-        self.layer.shadowOpacity = 0.05
+        self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
         self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
 
         statusContainerView.applyCornerStyle(.small)
+
+        permissionDeniedView.isHidden = true
+        permissionDeniedView.applyCornerStyle(.medium)
 
         registerForTraitChanges()
     }
@@ -77,7 +80,8 @@ extension HealthInfoCardCollectionViewCell {
         titleLabel.text = viewModel.itemID.kind.title
         statusProgressBarView.higherIsBetter = viewModel.itemID.kind.higherIsBetter
         statusProgressBarView.thresholdsValues = viewModel.itemID.kind.thresholdValues(age: viewModel.anchorAge)
-        
+        permissionDeniedView.isHidden = true
+
         switch state {
         case .idle:
             return // TODO: - 플레이스 홀더 UI 구성하기
@@ -121,6 +125,7 @@ extension HealthInfoCardCollectionViewCell {
             attrString = NSAttributedString(string: "- " + unitString)
             statusContainerView.isHidden = true
             statusProgressBarView.currentValue = nil
+            permissionDeniedView.isHidden = false
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoCardCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
         

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -72,7 +72,8 @@ extension HealthInfoCardCollectionViewCell {
             .sink { [weak self] state in  self?.render(for: state) }
             .store(in: &cancellable)
     }
-    
+
+    // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(for state: LoadState<InfoCardContent>) {
         var attrString: NSAttributedString
         let unitString = viewModel.itemID.kind.unitString

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.xib
@@ -77,17 +77,25 @@
                             </view>
                         </subviews>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zEs-T9-Tvs" customClass="PermissionDeniedFullView" customModule="Health" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="206"/>
+                    </view>
                 </subviews>
             </view>
             <constraints>
                 <constraint firstItem="V49-SI-zqi" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="16" id="8U4-xM-zV6"/>
+                <constraint firstAttribute="bottom" secondItem="zEs-T9-Tvs" secondAttribute="bottom" id="C3K-4e-ctI"/>
                 <constraint firstAttribute="bottom" secondItem="V49-SI-zqi" secondAttribute="bottom" constant="24" id="JwS-eP-OlZ"/>
                 <constraint firstItem="V49-SI-zqi" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="24" id="NFO-86-2qq"/>
                 <constraint firstAttribute="trailing" secondItem="V49-SI-zqi" secondAttribute="trailing" constant="16" id="ZYu-iy-BEF"/>
+                <constraint firstItem="zEs-T9-Tvs" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="k6l-98-JQv"/>
+                <constraint firstItem="zEs-T9-Tvs" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="txW-u5-rzp"/>
+                <constraint firstAttribute="trailing" secondItem="zEs-T9-Tvs" secondAttribute="trailing" id="yR7-Km-MkN"/>
             </constraints>
             <size key="customSize" width="461" height="253"/>
             <connections>
                 <outlet property="gaitStatusLabel" destination="gPV-e6-f8D" id="pTe-S0-4Hz"/>
+                <outlet property="permissionDeniedView" destination="zEs-T9-Tvs" id="ENv-fl-ctm"/>
                 <outlet property="statusContainerView" destination="5ac-L3-PfJ" id="hxD-X9-aIW"/>
                 <outlet property="statusProgressBarView" destination="5UC-7q-A0l" id="aKs-RE-KAr"/>
                 <outlet property="titleLabel" destination="wMV-cm-r7I" id="Tbm-Jb-USM"/>

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -18,6 +18,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var valueLabel: UILabel!
     @IBOutlet weak var unitLabel: UILabel!
     @IBOutlet weak var chartsContainerView: UIView!
+    @IBOutlet weak var permissionDeniedView: PermissionDeniedCompactView!
 
     private var chartsHostingController: UIHostingController<LineChartsView>?
 
@@ -25,8 +26,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
     private var cancellable: Set<AnyCancellable> = []
 
     override func layoutSubviews() {
-//       symbolContainerView.applyCornerStyle(.circular)
-        symbolContainerView.layer.cornerRadius = symbolContainerView.bounds.height / 2
+       symbolContainerView.applyCornerStyle(.circular)
     }
 
     override func prepareForReuse() {
@@ -53,6 +53,9 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
 
         chartsContainerView.backgroundColor = .boxBg
         chartsContainerView.isHidden = (traitCollection.horizontalSizeClass == .compact)
+
+        permissionDeniedView.isHidden = true
+        permissionDeniedView.symbomPointSize = 8
 
         registerForTraitChanges()
     }
@@ -90,6 +93,7 @@ extension HealthInfoStackCollectionViewCell {
         titleLabel.text = viewModel.itemID.kind.title
         symbolImageView.image = UIImage(systemName: viewModel.itemID.kind.systemName)
         unitLabel.text = unitString
+        permissionDeniedView.isHidden = true
 
         switch new {
         case .idle:
@@ -114,6 +118,7 @@ extension HealthInfoStackCollectionViewCell {
 
         case .denied:
             lblString = "-"
+            permissionDeniedView.isHidden = false
             print("🔵 건강 데이터에 접근할 수 있는 권한이 없음: HealthInfoStackCell (\(viewModel.itemID.kind.quantityTypeIdentifier))")
         }
 

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -42,7 +42,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
         self.layer.masksToBounds = false
         self.layer.borderColor = UIColor.separator.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
-        self.layer.shadowOpacity = 0.05
+        self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
         self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -36,9 +36,8 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
     }
 
     override func setupAttribute() {
-//        self.applyCornerStyle(.medium)
         self.backgroundColor = .boxBg
-        self.layer.cornerRadius = 12 // medium
+        self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
         self.layer.borderColor = UIColor.separator.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
@@ -84,6 +83,7 @@ extension HealthInfoStackCollectionViewCell {
             .store(in: &cancellable)
     }
 
+    // TODO: - 상태 코드 별로 함수로 나누는 리팩토링하기
     private func render(_ new: LoadState<InfoStackContent>, parent: UIViewController?) {
         var lblString: String
         let unitString = viewModel.itemID.kind.unitString

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.xib
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.xib
@@ -78,6 +78,14 @@
                             <constraint firstItem="qVC-yD-eOe" firstAttribute="height" secondItem="RYE-W8-flu" secondAttribute="height" multiplier="0.75" id="n21-UK-Euc"/>
                         </constraints>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1fw-km-7na" customClass="PermissionDeniedCompactView" customModule="Health" customModuleProvider="target">
+                        <rect key="frame" x="5" y="11" width="16" height="16"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="16" id="cfY-aK-bUO"/>
+                            <constraint firstAttribute="height" constant="16" id="wgk-VK-KJp"/>
+                        </constraints>
+                    </view>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
@@ -89,11 +97,14 @@
                     <variation key="heightClass=regular-widthClass=compact" constant="8"/>
                 </constraint>
                 <constraint firstAttribute="bottom" secondItem="RYE-W8-flu" secondAttribute="bottom" constant="8" id="m4r-xx-aEa"/>
+                <constraint firstItem="1fw-km-7na" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="5" id="owx-8L-XSG"/>
+                <constraint firstItem="1fw-km-7na" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="11" id="pI9-r8-Olk"/>
                 <constraint firstItem="RYE-W8-flu" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="8" id="soL-HM-HkW"/>
             </constraints>
             <size key="customSize" width="302" height="64"/>
             <connections>
                 <outlet property="chartsContainerView" destination="DDj-vA-Ec4" id="2eJ-fm-ynq"/>
+                <outlet property="permissionDeniedView" destination="1fw-km-7na" id="VHY-DF-nNu"/>
                 <outlet property="symbolContainerView" destination="qVC-yD-eOe" id="O2X-Xw-Akx"/>
                 <outlet property="symbolImageView" destination="hCH-M6-aWc" id="xfg-Zd-Ibw"/>
                 <outlet property="titleLabel" destination="lCs-nZ-F1Q" id="btX-cV-8pM"/>

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -34,12 +34,15 @@ final class DashboardViewModel {
 
     // TODO: - Alan 서버에서 요약문을 가져오는 서비스 객체 주입하기
     // TODO: - 코어 데이터에서 사용자 정보 가져오는 서비스 객체 주입하기
-    @Injected private var healthService: HealthService
+    @Injected private var healthService: (any HealthService)
 
     ///
     init(anchorDate: Date = .now) {
         self.anchorDate = anchorDate
     }
+
+
+    // MARK: - Build Layout
 
     ///
     func buildDashboardCells(for environment: DashboardEnvironment) {
@@ -138,6 +141,9 @@ final class DashboardViewModel {
         cardCells = newCells
     }
 }
+
+
+// MARK: - Load HKData
 
 extension DashboardViewModel {
 
@@ -343,6 +349,9 @@ extension DashboardViewModel {
         }
     }
 }
+
+
+// MARK: - Fetch CoreData
 
 extension DashboardViewModel {
 


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 대시보드의 각 셀에서 해당하는 건강 데이터에 접근할 수 없으면 `권한 없음` UI를 띄우도록 코드를 작성하였습니다. (앨런 AI 요약 셀 제외)
- 대시보드의 각 셀에서 그림자 불투명도를 살짝 높여 입체감을 주었습니다.

---

## 🧪 테스트시 유의 사항

- 설정 화면에서 권한 설정을 바꾸고, 다시 앱에 진입한다 하더라도 데이터가 갱신되지 않습니다. 앱을 완전히 종료 후 다시 여셔야 바뀐 권한에 맞게 데이터가 갱신됩니다.

---

## 📝 참고

- 아침에 구현한 `PermissionDeniedView`를 조금 더 범용적으로 사용할 수 있도록 개선이 필요해보입니다. (예: 데이터 불충분 예외)

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="1179" height="2556" alt="IMG_0453" src="https://github.com/user-attachments/assets/07708e35-579c-4564-a4a3-f8d77a936074" />  |  <img width="1179" height="2556" alt="IMG_0454" src="https://github.com/user-attachments/assets/f228f337-041a-4ee8-b3ca-0129a9bbd28e" />   |
| <img width="1179" height="2556" alt="IMG_0455" src="https://github.com/user-attachments/assets/d1893ff2-85b1-4efc-82cc-6fa6600df584" />   |  <img width="1179" height="2556" alt="IMG_0456" src="https://github.com/user-attachments/assets/200f989e-88d4-42c9-a33f-5b7091d4c93c" />   |
| <img width="1179" height="2556" alt="IMG_0457" src="https://github.com/user-attachments/assets/ffd9825c-1540-42cc-a712-ca9c97154e73" />   |   <img width="1179" height="2556" alt="IMG_0458" src="https://github.com/user-attachments/assets/d8c1b39a-21e0-4c6b-88e7-2c8132427192" />  |
|  <img width="1179" height="2556" alt="IMG_0460" src="https://github.com/user-attachments/assets/bbc7bc88-14e2-48fd-9592-26dbadff87b8" />  |   <img width="1179" height="2556" alt="IMG_0461" src="https://github.com/user-attachments/assets/d9d94487-84d2-4a44-873d-0b28d9e19add" />  |








---

### 💜 결과

-
