### PR TITLE
feat: `원형 프로그래스 바`의 선 두께 및 색상 변경, `MockHealthService`가 실제 유용한 값을 반환하도록 개선 (수정 #2)

### DIFF
--- a/Health/Core/DIContainer/DIContainer+Register.swift
+++ b/Health/Core/DIContainer/DIContainer+Register.swift
@@ -36,6 +36,20 @@ extension DIContainer {
         }
     }
 
+    /// 사용자 정보 관리 서비스를 의존성 주입 컨테이너에 등록합니다.
+    ///
+    /// `DefaultCoreDataUserService`는 `CoreDataUserService` 프로토콜을 구현하며,
+    /// Core Data를 통해 사용자 정보의 CRUD 작업을 처리합니다.
+    /// 해당 서비스는 컨테이너에서 `.coreDataUserService` 식별자를 사용하여
+    /// 타입 안전하게 해결할 수 있습니다.
+    ///
+    /// - Note: `CoreDataStack.shared`가 초기화되어 있어야 정상적으로 동작합니다.
+    func registerCoreDataUserService() {
+        self.register(.coreDataUserService) { _ in
+            return DefaultCoreDataUserService()
+        }
+    }
+
     /// 일일 걸음 수 관리를 담당하는 ViewModel을 의존성 주입 컨테이너에 등록합니다.
     ///
     /// `DailyStepViewModel`은 Core Data를 통해 일일 걸음 수 데이터의 CRUD 작업을 처리합니다.
@@ -93,6 +107,7 @@ extension DIContainer {
     func registerAllServices() {
         registerNetworkService()
         registerHealthService()
+        registerCoreDataUserService()
         registerDailyStepViewModel()
         registerGoalStepCountViewModel()
         registerStepSyncViewModel()

--- a/Health/Core/DIContainer/InjectIdentifier+Keys.swift
+++ b/Health/Core/DIContainer/InjectIdentifier+Keys.swift
@@ -35,6 +35,17 @@ extension InjectIdentifier {
         InjectIdentifier<HealthService>(type: HealthService.self)
     }
 
+    /// 사용자 정보 관리 서비스를 식별하는 정적 속성
+    ///
+    /// `CoreDataUserService` 프로토콜을 구현하는 서비스들을 의존성 주입 컨테이너에서
+    /// 등록하고 해결할 때 사용되는 타입 안전한 식별자입니다.
+    ///
+    /// - Returns: `CoreDataUserService` 타입의 `InjectIdentifier` 인스턴스
+    /// - Note: 이 식별자는 컴파일 타임에 타입 안전성을 보장합니다.
+    static var coreDataUserService: InjectIdentifier<CoreDataUserService> {
+        InjectIdentifier<CoreDataUserService>(type: CoreDataUserService.self)
+    }
+
     /// 일일 걸음 수 관리 ViewModel을 식별하는 정적 속성
     ///
     /// `DailyStepViewModel` 클래스를 의존성 주입 컨테이너에서

--- a/Health/Core/Indicators/ActivityIndicator/AlanLoadingIndicatorView.swift
+++ b/Health/Core/Indicators/ActivityIndicator/AlanLoadingIndicatorView.swift
@@ -1,0 +1,144 @@
+//
+//  AlanLoadingIndicatorView.swift
+//  Health
+//
+//  Created by 김건우 on 8/14/25.
+//
+
+import UIKit
+
+final class AlanLoadingIndicatorView: CoreView {
+
+    /// 로딩 인디케이터의 현재 상태를 나타내는 열거형입니다.
+    enum State {
+        /// 작업이 진행 중인 상태
+        case loading
+        /// 작업이 실패한 상태
+        case failed
+        /// 작업이 성공적으로 완료된 상태
+        case sucess
+    }
+
+    private let failedImageView = UIImageView()
+    private let loadingIndicatorView = CustomActivityIndicatorView()
+    private let titleLabel = UILabel()
+    private let indicatorStackView = UIStackView()
+
+    private var exclamationmarkCircleImage: UIImage? = {
+        let image = UIImage(systemName: "exclamationmark.circle.fill")
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular)
+            .applying(UIImage.SymbolConfiguration(paletteColors: [.systemRed]))
+        return image?.applyingSymbolConfiguration(config)
+    }()
+
+    private(set) var state: State = .loading
+    private var timer: Timer?
+    private var count: Int = 0
+
+    private let doingSummaryText = "AI가 열심히 요약 중이예요."
+    private let failedSummaryText = "AI가 요약에 실패했어요."
+
+    override func setupHierarchy() {
+        addSubview(indicatorStackView)
+        indicatorStackView.addArrangedSubviews(loadingIndicatorView, titleLabel)
+    }
+
+    override func setupAttribute() {
+        loadingIndicatorView.color = .accent
+        loadingIndicatorView.dotDiameter = 24
+        loadingIndicatorView.startAnimating()
+
+        titleLabel.text = doingSummaryText
+        titleLabel.textColor = .secondaryLabel
+        titleLabel.numberOfLines = 0
+
+        indicatorStackView.spacing = 8
+
+        failedImageView.image = exclamationmarkCircleImage
+        indicatorStackView.backgroundColor = .lightGray
+        setState(state)
+    }
+
+    override func setupConstraints() {
+        indicatorStackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            indicatorStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            indicatorStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            indicatorStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            indicatorStackView.topAnchor.constraint(equalTo: topAnchor)
+        ])
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            stopTimer()
+        }
+    }
+}
+
+extension AlanLoadingIndicatorView {
+
+    /// 로딩 인디케이터의 상태를 변경합니다.
+    ///
+    /// 전달된 상태 값에 따라 내부 UI를 해당 상태에 맞게 업데이트합니다.
+    ///
+    /// - Parameter new: 변경할 `AlanLoadingIndicatorView.State` 값.
+    ///   - `.loading`: 로딩 중 상태로 전환합니다.
+    ///   - `.failed`: 실패 상태로 전환합니다.
+    ///   - `.sucess`: 성공 상태로 전환합니다.
+    func setState(_ new: AlanLoadingIndicatorView.State) {
+        switch new {
+        case .loading: setLoadingState()
+        case .failed:  setFailedState()
+        case .sucess:  setSuccessState()
+        }
+    }
+
+    private func setLoadingState() {
+        titleLabel.text = doingSummaryText
+        failedImageView.removeFromSuperview()
+        indicatorStackView.insertArrangedSubview(loadingIndicatorView, at: 0)
+        indicatorStackView.spacing = 6
+        startTimer()
+    }
+
+    private func setFailedState() {
+        titleLabel.text = failedSummaryText
+        loadingIndicatorView.removeFromSuperview()
+        indicatorStackView.insertArrangedSubview(failedImageView, at: 0)
+        indicatorStackView.spacing = 8
+        stopTimer()
+    }
+
+    private func setSuccessState() {
+        isHidden = true
+        stopTimer()
+    }
+}
+
+fileprivate extension AlanLoadingIndicatorView {
+
+    func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.count += 1
+                let newText = self.doingSummaryText + Array(repeating: ".", count: self.count % 3).joined()
+                self.titleLabel.text = newText
+            }
+        }
+    }
+
+    func stopTimer() {
+        count = 0
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+#Preview {
+    let v = AlanLoadingIndicatorView()
+    v.setState(.loading)
+    return v
+}

--- a/Health/Core/Indicators/ActivityIndicator/AlanLoadingIndicatorView.swift
+++ b/Health/Core/Indicators/ActivityIndicator/AlanLoadingIndicatorView.swift
@@ -16,7 +16,7 @@ final class AlanLoadingIndicatorView: CoreView {
         /// 작업이 실패한 상태
         case failed
         /// 작업이 성공적으로 완료된 상태
-        case sucess
+        case success
     }
 
     private let failedImageView = UIImageView()
@@ -90,27 +90,30 @@ extension AlanLoadingIndicatorView {
         switch new {
         case .loading: setLoadingState()
         case .failed:  setFailedState()
-        case .sucess:  setSuccessState()
+        case .success: setSuccessState()
         }
     }
 
     private func setLoadingState() {
-        titleLabel.text = doingSummaryText
+        state = .loading
         failedImageView.removeFromSuperview()
         indicatorStackView.insertArrangedSubview(loadingIndicatorView, at: 0)
         indicatorStackView.spacing = 6
+        titleLabel.text = doingSummaryText
         startTimer()
     }
 
     private func setFailedState() {
-        titleLabel.text = failedSummaryText
+        state = .failed
         loadingIndicatorView.removeFromSuperview()
         indicatorStackView.insertArrangedSubview(failedImageView, at: 0)
         indicatorStackView.spacing = 8
+        titleLabel.text = failedSummaryText
         stopTimer()
     }
 
     private func setSuccessState() {
+        state = .success
         isHidden = true
         stopTimer()
     }
@@ -135,10 +138,4 @@ fileprivate extension AlanLoadingIndicatorView {
         timer?.invalidate()
         timer = nil
     }
-}
-
-#Preview {
-    let v = AlanLoadingIndicatorView()
-    v.setState(.loading)
-    return v
 }

--- a/Health/Core/Indicators/ActivityIndicator/CustomActivityIndicatorView.swift
+++ b/Health/Core/Indicators/ActivityIndicator/CustomActivityIndicatorView.swift
@@ -55,10 +55,7 @@ final class CustomActivityIndicatorView: UIView {
 	///
 	/// - 중요: 커스텀 뷰를 만들 때, 콘텐츠나 외부 제약과 무관하게
 	///   뷰 자체가 선호하는 크기가 있을 경우 이 프로퍼티를 재정의(override)
-	/// - 반환값: 뷰의 이상적인 너비와 높이를 나타내는 `CGSize`.
-	///  인디케이터 점(도형)의 지름 기준, 점이 커지고 겹치는 공간 포함해 약 2.2배 확장됨
-	///  최소 24pt 이상
-	///  예: dotDiameter가 10pt이면, 10 x 22 = 22pt면  최소 24 pt로 반환
+    /// - 반환값: 뷰의 지름(`dotDiameter`)을 너비와 높이로 하는 정사각형 크기
 	override var intrinsicContentSize: CGSize {
 		return CGSize(width: dotDiameter, height: dotDiameter)
 	}

--- a/Health/Core/Indicators/ActivityIndicator/CustomActivityIndicatorView.swift
+++ b/Health/Core/Indicators/ActivityIndicator/CustomActivityIndicatorView.swift
@@ -60,8 +60,7 @@ final class CustomActivityIndicatorView: UIView {
 	///  최소 24pt 이상
 	///  예: dotDiameter가 10pt이면, 10 x 22 = 22pt면  최소 24 pt로 반환
 	override var intrinsicContentSize: CGSize {
-		let side = max(dotDiameter * 2.2, 24)
-		return CGSize(width: side, height: side)
+		return CGSize(width: dotDiameter, height: dotDiameter)
 	}
 	
 	override func layoutSubviews() {

--- a/Health/Core/Storage/CoreData/CoreDataStack+Dummy.swift
+++ b/Health/Core/Storage/CoreData/CoreDataStack+Dummy.swift
@@ -61,7 +61,8 @@ extension CoreDataStack {
             dailyStep.goalStepCount = dummyGoal.goalStepCount
             dummyUser.addToDailyStep(dailyStep)
         }
-        
+
+
         // 4. 저장
         do {
             try context.save()

--- a/Health/Core/Storage/CoreData/CoreDataStack.swift
+++ b/Health/Core/Storage/CoreData/CoreDataStack.swift
@@ -8,6 +8,22 @@
 import CoreData
 import Foundation
 
+/// Core Data 작업 중 발생할 수 있는 오류를 정의한 열거형입니다.
+enum CoreDataError: Error {
+
+    /// 엔티티 생성 작업에 실패한 경우
+    case createError
+
+    /// 엔티티 조회 작업에 실패하거나, 해당 데이터가 존재하지 않는 경우
+    case readError
+
+    /// 엔티티 수정 작업에 실패한 경우
+    case updateError
+
+    /// 엔티티 삭제 작업에 실패한 경우
+    case deleteError
+}
+
 /// `CoreDataStack`은 Core Data의 기본 구성을 담당하는 클래스입니다.
 ///
 /// 앱 전반에서 공유되는 `NSPersistentContainer`와 `NSManagedObjectContext`를 관리하며,

--- a/Health/Core/Views/CircleProgressView/CircleProgressView.swift
+++ b/Health/Core/Views/CircleProgressView/CircleProgressView.swift
@@ -45,7 +45,7 @@ final class CircleProgressView: CoreView {
     ///
     /// 단색으로 표시할 경우 색상 하나만 전달하면 되며,
     /// 색상을 하나도 전달하지 않으면 런타임 오류가 발생합니다.
-    var foregroundLightColors: [UIColor] = [.accent, .segSelected, .accent] {
+    var foregroundLightColors: [UIColor] = [.accent, .appOffWhite, .accent] {
         didSet { self.setNeedsLayout() }
     }
 
@@ -53,7 +53,7 @@ final class CircleProgressView: CoreView {
     ///
     /// 단색으로 표시할 경우 색상 하나만 전달하면 되며,
     /// 색상을 하나도 전달하지 않으면 런타임 오류가 발생합니다.
-    var foregroundDarkColors: [UIColor] = [.accent, .segSelected, .accent] {
+    var foregroundDarkColors: [UIColor] = [.accent, .appOffWhite, .accent] {
         didSet { self.setNeedsLayout() }
     }
 

--- a/Health/Core/Views/CircleProgressView/CircleProgressView.swift
+++ b/Health/Core/Views/CircleProgressView/CircleProgressView.swift
@@ -104,7 +104,7 @@ final class CircleProgressView: CoreView {
             var percentageValue = currentValue / totalValue
             if percentageValue > 1 { percentageValue = 1 }
             percentageLabel.text = percentageValue
-                .formatted(.percent.precision(.fractionLength(1)))
+                .formatted(.percent.precision(.fractionLength(0)))
 
             let progressString = "\(currentValue.formatted()) / \(totalValue.formatted())"
             if let slashIndex = progressString.firstIndex(of: "/") {

--- a/Health/Core/Views/CircleProgressView/CircleProgressView.swift
+++ b/Health/Core/Views/CircleProgressView/CircleProgressView.swift
@@ -37,7 +37,7 @@ final class CircleProgressView: CoreView {
     }
 
     /// 진행률 원형 선의 두께입니다.
-    var foregroundLineWidth: CGFloat = 8 {
+    var foregroundLineWidth: CGFloat = 12 {
         didSet { self.setNeedsLayout() }
     }
 
@@ -45,7 +45,7 @@ final class CircleProgressView: CoreView {
     ///
     /// 단색으로 표시할 경우 색상 하나만 전달하면 되며,
     /// 색상을 하나도 전달하지 않으면 런타임 오류가 발생합니다.
-    var foregroundLightColors: [UIColor] = [.accent] {
+    var foregroundLightColors: [UIColor] = [.accent, .segSelected, .accent] {
         didSet { self.setNeedsLayout() }
     }
 
@@ -58,7 +58,7 @@ final class CircleProgressView: CoreView {
     }
 
     /// 배경 원형 선의 두께입니다.
-    var backgroundLineWidth: CGFloat = 8 {
+    var backgroundLineWidth: CGFloat = 12 {
         didSet { self.setNeedsLayout() }
     }
 

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -13,6 +13,10 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var summaryLabel: UILabel!
 
     private var cancellables: Set<AnyCancellable> = []
+    
+    private var borderWidth: CGFloat {
+        (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.75
+    }
 
     private var viewModel: AlanActivitySummaryCellViewModel!
 
@@ -25,18 +29,14 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
+        self.layer.borderWidth = borderWidth
 
         registerForTraitChanges()
     }
 
     private func registerForTraitChanges() {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.userInterfaceStyle == .dark {
-                self.layer.borderWidth = 0
-            } else {
-                self.layer.borderWidth = 0.5
-            }
+            self.layer.borderWidth = self.borderWidth
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -25,7 +25,7 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
+        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
 
         registerForTraitChanges()
     }
@@ -35,7 +35,7 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
             if self.traitCollection.userInterfaceStyle == .dark {
                 self.layer.borderWidth = 0
             } else {
-                self.layer.borderWidth = 1
+                self.layer.borderWidth = 0.5
             }
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -23,6 +23,8 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
     private var cancellable: Set<AnyCancellable> = []
 
     override func setupAttribute() {
+        self.layer.masksToBounds = false
+        
         chartsContainerView.applyCornerStyle(.medium)
         chartsContainerView.backgroundColor = .boxBg
         chartsContainerView.layer.masksToBounds = false
@@ -31,7 +33,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
         chartsContainerView.layer.shadowOpacity = 0.15
         chartsContainerView.layer.shadowOffset = CGSize(width: 2, height: 2)
         chartsContainerView.layer.shadowRadius = 5
-        chartsContainerView.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
+        chartsContainerView.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
 
         averageTitleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         rangeOfDateLabel.font = .systemFont(ofSize: 13, weight: .semibold)
@@ -49,7 +51,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
             if self.traitCollection.userInterfaceStyle == .dark {
                 self.chartsContainerView.layer.borderWidth = 0
             } else {
-                self.chartsContainerView.layer.borderWidth = 1
+                self.chartsContainerView.layer.borderWidth = 0.5
             }
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -22,6 +22,14 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
     
     private var cancellable: Set<AnyCancellable> = []
 
+    private var borderWidth: CGFloat {
+        (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.75
+    }
+    
+    override func prepareForReuse() {
+        cancellable.removeAll()
+    }
+    
     override func setupAttribute() {
         self.layer.masksToBounds = false
         
@@ -33,7 +41,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
         chartsContainerView.layer.shadowOpacity = 0.15
         chartsContainerView.layer.shadowOffset = CGSize(width: 2, height: 2)
         chartsContainerView.layer.shadowRadius = 5
-        chartsContainerView.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
+        chartsContainerView.layer.borderWidth = borderWidth
 
         averageTitleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         rangeOfDateLabel.font = .systemFont(ofSize: 13, weight: .semibold)
@@ -48,11 +56,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
 
     private func registerForTraitChanges() {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.userInterfaceStyle == .dark {
-                self.chartsContainerView.layer.borderWidth = 0
-            } else {
-                self.chartsContainerView.layer.borderWidth = 0.5
-            }
+            self.chartsContainerView.layer.borderWidth = self.borderWidth
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -21,6 +21,10 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
 
     private var cancellable: Set<AnyCancellable> = []
     
+    private var borderWidth: CGFloat {
+        (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.75
+    }
+    
     private var percentageFormatter: NumberFormatter = {
         let nf = NumberFormatter()
         nf.numberStyle = .percent
@@ -40,7 +44,7 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
+        self.layer.borderWidth = borderWidth
 
         statusContainerView.applyCornerStyle(.small)
 
@@ -52,11 +56,7 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
 
     private func registerForTraitChanges() {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.userInterfaceStyle == .dark {
-                self.layer.borderWidth = 0
-            } else {
-                self.layer.borderWidth = 0.5
-            }
+            self.layer.borderWidth = self.borderWidth
         }
     }
 }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -40,7 +40,7 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
+        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
 
         statusContainerView.applyCornerStyle(.small)
 
@@ -55,7 +55,7 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
             if self.traitCollection.userInterfaceStyle == .dark {
                 self.layer.borderWidth = 0
             } else {
-                self.layer.borderWidth = 1
+                self.layer.borderWidth = 0.5
             }
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -44,7 +44,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1
+        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
 
         symbolContainerView.backgroundColor = .systemGray5
 
@@ -65,7 +65,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
             if self.traitCollection.userInterfaceStyle == .dark {
                 self.layer.borderWidth = 0
             } else {
-                self.layer.borderWidth = 1
+                self.layer.borderWidth = 0.5
             }
         }
     }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -20,19 +20,24 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var chartsContainerView: UIView!
     @IBOutlet weak var permissionDeniedView: PermissionDeniedCompactView!
 
+    private var cancellable: Set<AnyCancellable> = []
     private var chartsHostingController: UIHostingController<LineChartsView>?
 
+    private var borderWidth: CGFloat {
+        (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.75
+    }
+    
     private var viewModel: HealthInfoStackCellViewModel!
-    private var cancellable: Set<AnyCancellable> = []
-
+    
     override func layoutSubviews() {
        symbolContainerView.applyCornerStyle(.circular)
     }
 
     override func prepareForReuse() {
-        chartsHostingController = nil
-        chartsContainerView.subviews.forEach { $0.removeFromSuperview() }
         cancellable.removeAll()
+        chartsContainerView.subviews.forEach { $0.removeFromSuperview() }
+        chartsHostingController?.removeFromParent()
+        chartsHostingController = nil
     }
 
     override func setupAttribute() {
@@ -44,7 +49,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)
         self.layer.shadowRadius = 5
-        self.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.5
+        self.layer.borderWidth = borderWidth
 
         symbolContainerView.backgroundColor = .systemGray5
 
@@ -62,11 +67,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
 
     private func registerForTraitChanges() {
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.userInterfaceStyle == .dark {
-                self.layer.borderWidth = 0
-            } else {
-                self.layer.borderWidth = 0.5
-            }
+            self.layer.borderWidth = self.borderWidth
         }
     }
 }

--- a/Health/Resources/Assets.xcassets/appOffWhite.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/appOffWhite.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Health/Services/CoreDataSerice/DefaultCoreDataUserService.swift
+++ b/Health/Services/CoreDataSerice/DefaultCoreDataUserService.swift
@@ -1,0 +1,107 @@
+//
+//  DefaultCoreDataUserService.swift
+//  Health
+//
+//  Created by 김건우 on 8/14/25.
+//
+
+import Foundation
+
+/// `DefaultCoreDataUserService`
+///
+/// Core Data를 사용하여 사용자 정보를 생성, 조회, 수정, 삭제하는 서비스 구현체입니다.
+/// 이 클래스는 `CoreDataUserService` 프로토콜을 준수하며,
+/// 내부적으로 `CoreDataStack`을 활용해 `UserInfoEntity` 엔티티를 관리합니다.
+final class DefaultCoreDataUserService: CoreDataUserService {
+
+    private let coreDataStack: CoreDataStack
+
+    /// 지정 이니셜라이저입니다.
+    /// - Parameter coreDataStack: Core Data 작업에 사용할 `CoreDataStack` 객체입니다. 기본값은 `.shared`입니다.
+    init(coreDataStack: CoreDataStack = .shared) {
+        self.coreDataStack = coreDataStack
+    }
+
+    /// 새로운 사용자 정보를 Core Data에 생성합니다.
+    /// - Parameters:
+    ///   - id: 사용자의 고유 식별자(UUID). 기본값은 새로 생성됩니다.
+    ///   - age: 나이(정수).
+    ///   - gender: 성별(문자열).
+    ///   - height: 키(센티미터 단위, Double).
+    ///   - weight: 몸무게(킬로그램 단위, Double).
+    ///   - diseases: 사용자가 가지고 있는 질병 목록(옵션).
+    ///   - date: 생성 시각. 기본값은 현재 시간(`.now`)입니다.
+    /// - Throws: Core Data에 생성 작업 실패 시 `CoreDataError.createError`를 던집니다.
+    func createOneUer(
+        id: UUID = UUID(),
+        age: Int,
+        gender: String,
+        height: Double,
+        weight: Double,
+        diseases: [Disease]?,
+        createdAt date: Date = .now
+    ) throws {
+        let userEntity = UserInfoEntity(context: coreDataStack.viewContext)
+        userEntity.id = id
+        userEntity.age = Int16(age)
+        userEntity.gender = gender
+        userEntity.height = height
+        userEntity.weight = weight
+        userEntity.createdAt = date
+        userEntity.diseases = diseases
+        coreDataStack.saveContext()
+    }
+
+    /// 저장된 사용자 정보를 하나 가져옵니다.
+    /// - Returns: `UserInfoEntity` 객체.
+    /// - Throws: 저장된 사용자가 없거나, 읽기 작업이 실패한 경우 `CoreDataError.readError`를 던집니다.
+    func fetchOneUser() throws -> UserInfoEntity {
+        do {
+            let users: [UserInfoEntity] = try coreDataStack.fetch()
+            guard let user = users.first else { throw CoreDataError.readError }
+            return user
+        } catch {
+            throw CoreDataError.readError
+        }
+    }
+
+    /// 저장된 사용자 정보를 수정합니다.
+    /// - Parameters:
+    ///   - age: 변경할 나이(옵션).
+    ///   - gender: 변경할 성별(옵션).
+    ///   - height: 변경할 키(옵션).
+    ///   - weight: 변경할 몸무게(옵션).
+    ///   - diseases: 변경할 질병 목록(옵션).
+    /// - Throws: 업데이트 실패 시 `CoreDataError.updateError`를 던집니다.
+    func updateOneUser(
+        age: Int? = nil,
+        gender: String? = nil,
+        height: Double? = nil,
+        weight: Double? = nil,
+        diseases: [Disease]? = nil
+    ) throws {
+        do {
+            let userEntity: UserInfoEntity = try fetchOneUser()
+            if let age { userEntity.age = Int16(age) }
+            if let gender { userEntity.gender = gender }
+            if let height { userEntity.height = height }
+            if let weight { userEntity.weight = weight }
+            if let diseases { userEntity.diseases = diseases }
+            coreDataStack.saveContext()
+        } catch {
+            throw CoreDataError.updateError
+        }
+    }
+
+    /// 저장된 사용자 정보를 삭제합니다.
+    /// - Throws: 삭제 작업 실패 시 `CoreDataError.deleteError`를 던집니다.
+    func deleteOneUser() throws {
+        do {
+            let userEntity: UserInfoEntity = try fetchOneUser()
+            try coreDataStack.delete(userEntity)
+        } catch {
+            throw CoreDataError.deleteError
+        }
+    }
+
+}

--- a/Health/Services/CoreDataSerice/Protocol/CoreDataUserService.swift
+++ b/Health/Services/CoreDataSerice/Protocol/CoreDataUserService.swift
@@ -20,7 +20,7 @@ protocol CoreDataUserService {
     ///   - diseases: 사용자가 가지고 있는 질병 목록(옵션).
     ///   - date: 생성 시각. 기본값은 현재 시간(`.now`)입니다.
     /// - Throws: Core Data 생성 작업 실패 시 오류를 던집니다.
-    func createOneUer(
+    func createUserInfo(
         id: UUID,
         age: Int,
         gender: String,
@@ -28,12 +28,12 @@ protocol CoreDataUserService {
         weight: Double,
         diseases: [Disease]?,
         createdAt date: Date
-    ) throws
+    ) async throws
 
     /// 저장된 사용자 정보를 하나 가져옵니다.
     /// - Returns: `UserInfoEntity` 객체.
     /// - Throws: 저장된 사용자가 없거나, 읽기 작업이 실패한 경우 오류를 던집니다.
-    func fetchOneUser() throws -> UserInfoEntity
+    func fetchUserInfo() throws -> UserInfoEntity
 
     /// 저장된 사용자 정보를 수정합니다.
     /// - Parameters:
@@ -43,15 +43,15 @@ protocol CoreDataUserService {
     ///   - weight: 변경할 몸무게(옵션).
     ///   - diseases: 변경할 질병 목록(옵션).
     /// - Throws: 업데이트 실패 시 오류를 던집니다.
-    func updateOneUser(
+    func updateUserInfo(
         age: Int?,
         gender: String?,
         height: Double?,
         weight: Double?,
         diseases: [Disease]?
-    ) throws
+    ) async throws
 
     /// 저장된 사용자 정보를 삭제합니다.
     /// - Throws: 삭제 작업 실패 시 오류를 던집니다.
-    func deleteOneUser() throws
+    func deleteUserInfo() async throws
 }

--- a/Health/Services/CoreDataSerice/Protocol/CoreDataUserService.swift
+++ b/Health/Services/CoreDataSerice/Protocol/CoreDataUserService.swift
@@ -1,0 +1,57 @@
+//
+//  CoreDataUserService.swift
+//  Health
+//
+//  Created by 김건우 on 8/14/25.
+//
+
+import Foundation
+
+@MainActor
+protocol CoreDataUserService {
+
+    /// 새로운 사용자 정보를 Core Data에 생성합니다.
+    /// - Parameters:
+    ///   - id: 사용자의 고유 식별자(UUID). 기본값은 새로 생성됩니다.
+    ///   - age: 나이(정수).
+    ///   - gender: 성별(문자열).
+    ///   - height: 키(센티미터 단위, Double).
+    ///   - weight: 몸무게(킬로그램 단위, Double).
+    ///   - diseases: 사용자가 가지고 있는 질병 목록(옵션).
+    ///   - date: 생성 시각. 기본값은 현재 시간(`.now`)입니다.
+    /// - Throws: Core Data 생성 작업 실패 시 오류를 던집니다.
+    func createOneUer(
+        id: UUID,
+        age: Int,
+        gender: String,
+        height: Double,
+        weight: Double,
+        diseases: [Disease]?,
+        createdAt date: Date
+    ) throws
+
+    /// 저장된 사용자 정보를 하나 가져옵니다.
+    /// - Returns: `UserInfoEntity` 객체.
+    /// - Throws: 저장된 사용자가 없거나, 읽기 작업이 실패한 경우 오류를 던집니다.
+    func fetchOneUser() throws -> UserInfoEntity
+
+    /// 저장된 사용자 정보를 수정합니다.
+    /// - Parameters:
+    ///   - age: 변경할 나이(옵션).
+    ///   - gender: 변경할 성별(옵션).
+    ///   - height: 변경할 키(옵션).
+    ///   - weight: 변경할 몸무게(옵션).
+    ///   - diseases: 변경할 질병 목록(옵션).
+    /// - Throws: 업데이트 실패 시 오류를 던집니다.
+    func updateOneUser(
+        age: Int?,
+        gender: String?,
+        height: Double?,
+        weight: Double?,
+        diseases: [Disease]?
+    ) throws
+
+    /// 저장된 사용자 정보를 삭제합니다.
+    /// - Throws: 삭제 작업 실패 시 오류를 던집니다.
+    func deleteOneUser() throws
+}

--- a/Health/Services/HealthService/MockHealthService.swift
+++ b/Health/Services/HealthService/MockHealthService.swift
@@ -5,7 +5,6 @@
 //  Created by 김건우 on 8/6/25.
 //
 
-import Foundation
 import HealthKit
 
 /// HealthKit 데이터를 처리하는 목 구현체입니다.
@@ -13,45 +12,31 @@ import HealthKit
 /// - Important: 임의의 목(mock) 데이터만 반환합니다. 반드시 `RELEASE` 스킴으로 전환 후, 테스트를 진행하세요.
 final class MockHealthService: HealthService {
 
-    private let healthStore = HKHealthStore()
-
-    private(set) var typesForAuthorization: Set<HKQuantityType>
     init() {
-        typesForAuthorization = [
-            HKQuantityType(.activeEnergyBurned),                // 활동 에너지
-            HKQuantityType(.basalEnergyBurned),                 // 휴식 에너지
-            HKQuantityType(.distanceWalkingRunning),            // 걷기 + 달리기 거리
-            HKQuantityType(.appleExerciseTime),                 // 운동하기 시간
-            HKQuantityType(.stepCount),                         // 걸음 수
-            HKQuantityType(.walkingStepLength),                 // 보행 보폭
-            HKQuantityType(.walkingAsymmetryPercentage),        // 보행 비대칭성
-            HKQuantityType(.walkingSpeed),                      // 보행 속도
-            HKQuantityType(.walkingDoubleSupportPercentage),    // 이중 지지 시간
-            HKQuantityType(.height),                            // 신장(height)
-            HKQuantityType(.bodyMass),                          // 몸무게
-            HKQuantityType(.bodyMassIndex),                     // BMI 수치
-        ]
+//        HKQuantityType(.activeEnergyBurned)                // 활동 에너지
+//        HKQuantityType(.basalEnergyBurned)                 // 휴식 에너지
+//        HKQuantityType(.distanceWalkingRunning)            // 걷기 + 달리기 거리
+//        HKQuantityType(.appleExerciseTime)                 // 운동하기 시간
+//        HKQuantityType(.stepCount)                         // 걸음 수
+//        HKQuantityType(.walkingStepLength)                 // 보행 보폭
+//        HKQuantityType(.walkingAsymmetryPercentage)        // 보행 비대칭성
+//        HKQuantityType(.walkingSpeed)                      // 보행 속도
+//        HKQuantityType(.walkingDoubleSupportPercentage)    // 이중 지지 시간
+//        HKQuantityType(.height)                            // 신장(height)
+//        HKQuantityType(.bodyMass)                          // 몸무게
+//        HKQuantityType(.bodyMassIndex)                     // BMI 수치
     }
 
     // MARK: - Authorization
 
-    ///
-    /// - Important: `DEBUG` 모드에서는 아무런 동작을 수행하지 않습니다.
-    /// 반드시 `RELEASE` 스킴으로 전환 후, 호출하세요.
     func requestAuthorization() async throws -> Bool {
         return true
     }
 
-    ///
-    /// - Important: `DEBUG` 모드에서는 `true` 값만 반환합니다.
-    /// 반드시 `RELEASE` 스킴으로 전환 후, 호출하세요.
     func checkHasAnyReadPermission() async -> Bool {
         return true
     }
 
-    ///
-    /// - Important: `DEBUG` 모드에서는 `true` 값만 반환합니다.
-    /// 반드시 `RELEASE` 스킴으로 전환 후, 호출하세요.
     func checkHasReadPermission(for identifier: HKQuantityTypeIdentifier) async -> Bool {
         return true
     }
@@ -67,25 +52,9 @@ final class MockHealthService: HealthService {
         sortDescriptors: [NSSortDescriptor]? = nil,
         unit: HKUnit
     ) async throws -> [HKData] {
-        let samples: [HKData] = (0..<10).map { index in
-            let date = Date.now.addingTimeInterval(TimeInterval(-index * 86_400))
-            let (startDay, endDay) = date.rangeOfDay()
-            return HKData(startDate: startDay, endDate: endDay, value: Double.random(in: 0..<10))
-        }
-
-        return Array(samples.prefix(through: limit))
+        let (startDate, endDate) = Date.now.rangeOfDay()
+        return [HKData(startDate: startDate, endDate: endDate, value: 10.0)]
     }
-
-    func fetchSamples(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        limit: Int = HKObjectQueryNoLimit,
-        sortDescriptors: [NSSortDescriptor]? = nil
-    ) async throws -> [HKQuantitySample] {
-        fatalError("Does not implement in MockHealthService")
-    }
-
 
 
     // MARK: - Statistics
@@ -97,18 +66,22 @@ final class MockHealthService: HealthService {
         options: HKStatisticsOptions,
         unit: HKUnit
     ) async throws -> HKData {
-        let date = Date.now
-        let (startDay, endDay) = date.rangeOfDay()
-        return HKData(startDate: startDay, endDate: endDay, value: 1.4)
-    }
+        let (startDate, endDate) = Date.now.rangeOfDay()
 
-    func fetchStatistics(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        options: HKStatisticsOptions
-    ) async throws -> HKStatistics {
-        fatalError("Does not implement in MockHealthService")
+        let mockValues: [HKQuantityTypeIdentifier: Double] = [
+            .activeEnergyBurned: 148.0,           // 활동 에너지 (kcal)
+            .basalEnergyBurned: 1400.0,           // 휴식 에너지 (kcal)
+            .distanceWalkingRunning: 80.0,        // 걷기+달리기 거리 (km )
+            .appleExerciseTime: 42.0,             // 운동 시간 (분)
+            .stepCount: 8_540,                    // 걸음 수
+            .walkingStepLength: 72,               // 보행 보폭 (cm)
+            .walkingAsymmetryPercentage: 0.27,    // 보행 비대칭성 (%)
+            .walkingSpeed: 1.32,                  // 보행 속도 (m/s)
+            .walkingDoubleSupportPercentage: 0.17 // 이중 지지 시간 (%)
+        ]
+
+        let value = mockValues[identifier] ?? -1
+        return HKData(startDate: startDate, endDate: endDate, value: value)
     }
 
 
@@ -122,50 +95,12 @@ final class MockHealthService: HealthService {
         interval intervalComponents: DateComponents,
         unit: HKUnit
     ) async throws -> [HKData] {
-        let samples: [HKData] = (0..<7).map { index in
-            let date = Date.now.addingTimeInterval(TimeInterval(-index * 86_400))
+        let hkDatas: [HKData] = (0..<7).map { index in
+            let date = Date.now.addingDays(index)!
             let (startDay, endDay) = date.rangeOfDay()
             return HKData(startDate: startDay, endDate: endDay, value: Double.random(in: 1..<1000))
         }
 
-        return samples
-    }
-
-    func fetchStatisticsCollection(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        options: HKStatisticsOptions,
-        interval intervalComponents: DateComponents
-    ) async throws -> [HKStatistics] {
-        fatalError("Does not implement in MockHealthService")
-    }
-}
-
-
-
-
-fileprivate extension HKStatisticsOptions{
-
-    func quantity(for statistics: HKStatistics, unit: HKUnit) -> Double? {
-        var quantity: HKQuantity?
-        switch self {
-        case _ where self.contains(.cumulativeSum):
-            quantity = statistics.sumQuantity()
-        case _ where self.contains(.mostRecent):
-            quantity = statistics.mostRecentQuantity()
-        case _ where self.contains(.discreteAverage):
-            quantity = statistics.averageQuantity()
-        case _ where self.contains(.discreteMin):
-            quantity = statistics.minimumQuantity()
-        case _ where self.contains(.discreteMax):
-            quantity = statistics.maximumQuantity()
-        default:
-            return nil
-        }
-
-        guard let value = quantity?.doubleValue(for: unit)
-        else { return nil }
-        return value
+        return hkDatas
     }
 }

--- a/Health/Services/HealthService/Protocol/HealthService.swift
+++ b/Health/Services/HealthService/Protocol/HealthService.swift
@@ -85,30 +85,6 @@ protocol HealthService {
         unit: HKUnit
     ) async throws -> [HKData]
 
-    /// 지정한 HealthKit 양적 데이터(identifier)에 해당하는 샘플 데이터를 비동기적으로 가져옵니다.
-    ///
-    /// - Parameters:
-    ///   - identifier: 가져올 `HKQuantityTypeIdentifier`입니다. 예: `.stepCount`, `.walkingSpeed`.
-    ///   - startDate: 데이터를 조회할 시작 날짜입니다.
-    ///   - endDate: 데이터를 조회할 종료 날짜입니다.
-    ///   - limit: 가져올 데이터 개수의 최대값입니다. 기본값은 `HKObjectQueryNoLimit`입니다.
-    ///   - sortDescriptors: 정렬 방식입니다. 예: 종료일 기준 내림차순 등.
-    ///
-    /// - Returns: 조건에 해당하는 `[HKQuantitySample]` 배열을 반환합니다.
-    /// - Throws: HealthKit 권한이 없거나, 데이터 조회 중 문제가 발생하면 오류를 throw합니다.
-    ///
-    /// 사전에 `HKHealthStore.requestAuthorization`을 통해 권한이 승인되어 있어야 하며,
-    /// 권한이 없을 경우 런타임 중 오류가 발생할 수 있습니다.
-    func fetchSamples(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        limit: Int,
-        sortDescriptors: [NSSortDescriptor]?
-    ) async throws -> [HKQuantitySample]
-
-
-
     /// 지정한 양적 데이터(identifier)에 대해 통계 값을 비동기적으로 조회하고, 결과 값을 단위에 맞게 변환하여 반환합니다.
     ///
     /// - Parameters:
@@ -136,33 +112,6 @@ protocol HealthService {
         unit: HKUnit
     ) async throws -> HKData
 
-    /// 지정한 양적 데이터(identifier)에 대해 통계 정보를 비동기적으로 가져옵니다.
-    ///
-    /// - Parameters:
-    ///   - identifier: 조회할 `HKQuantityTypeIdentifier`입니다. 예: `.stepCount`, `.activeEnergyBurned`.
-    ///   - startDate: 통계를 계산할 시작 날짜입니다.
-    ///   - endDate: 통계를 계산할 종료 날짜입니다.
-    ///   - options: 통계를 계산할 방식입니다. 예: `.cumulativeSum`, `.discreteAverage`, `.mostRecent` 등.
-    ///
-    /// - Returns: 지정한 옵션에 따라 계산된 `HKStatistics` 객체를 반환합니다.
-    /// - Throws: HealthKit 권한이 없거나 데이터가 존재하지 않을 경우 오류를 throw합니다.
-    ///
-    /// 사전에 `HKHealthStore.requestAuthorization`을 통해 권한이 승인되어 있어야 하며,
-    /// 권한이 없을 경우 런타임 중 오류가 발생할 수 있습니다.
-    ///
-    /// - Important: `identifier`와 `options`의 조합에 따라 통계 계산이 불가능한 경우가 있을 수 있으므로, 매우 주의해서 전달해야 합니다.
-    /// 예를 들어, 보행 비대칭성(`walkingAsymmetryPercentage`)은 누적이 의미 없는 데이터이므로 `.cumulativeSum` 옵션과 함께 사용할 수 없습니다.
-    /// 이처럼 부적절한 조합으로 함수를 호출할 경우, 런타임 중 오류가 발생할 수 있습니다.
-    /// HealthKit 문서를 참고하여 각 데이터 타입에 적절한 `HKStatisticsOptions`를 선택하세요.
-    func fetchStatistics(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        options: HKStatisticsOptions
-    ) async throws -> HKStatistics
-
-
-
     /// 지정한 양적 데이터(identifier)에 대해 일정 구간(interval) 단위로 통계 정보를 비동기적으로 가져오고,
     /// 각 통계 구간의 시작/종료 시간 및 수치를 단위에 맞게 변환하여 반환합니다.
     ///
@@ -189,28 +138,4 @@ protocol HealthService {
         interval intervalComponents: DateComponents,
         unit: HKUnit
     ) async throws -> [HKData]
-    
-    /// 지정한 양적 데이터(identifier)에 대해 일정 구간(interval) 단위로 통계 정보를 비동기적으로 가져옵니다.
-    ///
-    /// - Parameters:
-    ///   - identifier: 조회할 `HKQuantityTypeIdentifier`입니다. 예: `.stepCount`, `.walkingSpeed`.
-    ///   - startDate: 통계를 계산할 시작 날짜입니다.
-    ///   - endDate: 통계를 계산할 종료 날짜입니다.
-    ///   - options: 통계를 계산할 방식입니다. 예: `.cumulativeSum`, `.discreteAverage` 등.
-    ///   - intervalComponents: 통계를 구간별로 나누기 위한 `DateComponents`입니다. 예: 하루 단위 → `DateComponents(day: 1)`
-    ///
-    /// - Returns: 각 구간에 해당하는 `HKStatistics` 객체의 배열을 반환합니다.
-    /// - Throws: HealthKit 권한이 없거나, 데이터 조회 중 문제가 발생할 경우 오류를 throw합니다.
-    ///
-    /// - Important: `identifier`와 `options`의 조합에 따라 통계 계산이 불가능한 경우가 있으므로, 매우 주의해서 전달해야 합니다.
-    ///              예를 들어, 보행 비대칭성(`walkingAsymmetryPercentage`)은 누적이 의미 없는 데이터이므로 `.cumulativeSum` 옵션과 함께 사용할 수 없습니다.
-    ///              이처럼 부적절한 조합으로 함수를 호출하면 런타임 중 오류가 발생할 수 있습니다.
-    ///              반드시 Apple의 HealthKit 공식 문서를 참고하여 적절한 옵션을 선택하세요.
-    func fetchStatisticsCollection(
-        for identifier: HKQuantityTypeIdentifier,
-        from startDate: Date,
-        to endDate: Date,
-        options: HKStatisticsOptions,
-        interval intervalComponents: DateComponents
-    ) async throws -> [HKStatistics]
 }

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -158,7 +158,7 @@ extension DashboardViewModel {
 
     func loadHKDataForGoalRingCells() {
         let (_, goalStepCount) = fetchCoreDataUser()
-
+        
         Task {
             for (_, vm) in self.goalRingCells {
                 vm.setState(.loading)
@@ -358,7 +358,7 @@ extension DashboardViewModel {
 
     func fetchCoreDataUser() -> (age: Int, goalStep: Int) {
         // ⚠️ 사용자 및 목표 걸음 수가 제대로 등록되어 있으면 않으면 크래시
-        let user = try! coreDataUserService.fetchOneUser()
+        let user = try! coreDataUserService.fetchUserInfo()
         let goalStepCount = goalStepService.goalStepCount(for: anchorDate.endOfDay())!
         return (Int(user.age), Int(goalStepCount))
     }

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -32,8 +32,9 @@ final class DashboardViewModel {
     private(set) var chartsIDs: [DashboardBarChartsCellViewModel.ItemID] = []
     private(set) var chartsCells: [DashboardBarChartsCellViewModel.ItemID: DashboardBarChartsCellViewModel] = [:]
 
-    // TODO: - Alan 서버에서 요약문을 가져오는 서비스 객체 주입하기
-    // TODO: - 코어 데이터에서 사용자 정보 가져오는 서비스 객체 주입하기
+    private let alanService = AlanViewModel()
+    @Injected private var goalStepService: GoalStepCountViewModel
+    @Injected private var coreDataUserService: (any CoreDataUserService)
     @Injected private var healthService: (any HealthService)
 
     ///
@@ -123,7 +124,7 @@ final class DashboardViewModel {
     }
 
     private func buildCardCells() {
-        let (age, _) = fetchCoreDataUserInfo()
+        let (age, _) = fetchCoreDataUser()
 
         let newIDs = [
             HealthInfoCardCellViewModel.ItemID(kind: .walkingSpeed),
@@ -156,7 +157,7 @@ extension DashboardViewModel {
     }
 
     func loadHKDataForGoalRingCells() {
-        let (_, goalStepCount) = fetchCoreDataUserInfo()
+        let (_, goalStepCount) = fetchCoreDataUser()
 
         Task {
             for (_, vm) in self.goalRingCells {
@@ -355,21 +356,21 @@ extension DashboardViewModel {
 
 extension DashboardViewModel {
 
-    ///
-    func fetchCoreDataUserInfo() -> (age: Int, goalStep: Int) {
-        (27, 10_000)  // TODO: - 사용자 목표 걸음 수를 가져오는 코드 작성하기
+    func fetchCoreDataUser() -> (age: Int, goalStep: Int) {
+        // ⚠️ 사용자 및 목표 걸음 수가 제대로 등록되어 있으면 않으면 크래시
+        let user = try! coreDataUserService.fetchOneUser()
+        let goalStepCount = goalStepService.goalStepCount(for: anchorDate.endOfDay())!
+        return (Int(user.age), Int(goalStepCount))
     }
 }
 
 extension DashboardViewModel {
 
-    ///
     @available(*, deprecated)
     func requestHKAutorizationIfNeeded() async throws -> Bool {
         return try await healthService.requestAuthorization()
     }
 
-    ///
     func fetchStatisticsHKData(
         for identifier: HKQuantityTypeIdentifier,
         from startDate: Date,
@@ -386,7 +387,6 @@ extension DashboardViewModel {
         )
     }
 
-    ///
     func fetchStatisticsCollectionHKData(
         for identifier: HKQuantityTypeIdentifier,
         from startDate: Date,


### PR DESCRIPTION
[Notion Task]()

---

## ✅ 변경사항

- `MockHealthService`가 전달되는 건강 데이터 타입에 따라 알맞은 값을 반환하도록 코드를 개선하였습니다.
- `원형 프로그래스 바`의 선 두께, 그라디언트 색상을 변경하였습니다. (라이트 모드에서도 그라디언트가 적용되도록)
- 대시보드의 각 셀에서 `BorderWith` 값을 1에서 0.75로 조정하였습니다.
- `CoreDataUserService` 서비스 객체 생성 및 DIContainer에 주입하였습니다. (뷰-모델이 SwiftUI로 작성되어 있어서.. 수정하기도 그래서 하나 작성했어요) **`수정 #1`**
- 대시보드 및 분석 화면에서 사용할 `AlanLoadingIndicatorView` UI를 작성했습니다.  **`수정 #2`**

## 🏞️ 이미지

| | |
| :--: | :--: |
| <img width="349" height="59" alt="스크린샷 2025-08-15 오전 12 48 01" src="https://github.com/user-attachments/assets/5f59d209-6e78-454d-b41a-14b59fa441c1" /> | <img width="350" height="62" alt="스크린샷 2025-08-15 오전 12 47 51" src="https://github.com/user-attachments/assets/da1bccb8-881e-407c-8cd5-85b0fd53e00f" /> |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 00 54 20" src="https://github.com/user-attachments/assets/f46e70a4-14cc-49a4-8222-b72d22fd626e" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 00 54 28" src="https://github.com/user-attachments/assets/92572ee7-c7dd-4ef9-9ffa-10e7ce980672" /> |

## 기타

- 상기 변경사항 모두 강사님께서 피드백해주신 내용입니다.
- (시간 아까워서 이것저것) 작업을 하다보니 짬뽕이 되버렸는데😂 다음엔 이렇게 안할게요. 죄송합니다.
