### PR TITLE
feat: CoreData로부터 달력에 걸음 수 데이터를 제공하는 CalendarStepService 추가

### DIFF
--- a/Health/Application/SceneDelegate.swift
+++ b/Health/Application/SceneDelegate.swift
@@ -55,12 +55,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-#if DEBUG
-        print("앱 활성화됨 → 걸음 데이터 동기화")
-#endif
-        Task {
-            await stepSyncViewModel.syncDailySteps()
-        }
+    	// TODO: 건강 앱 연동 후 HealthKit 걸음 데이터 동기화 작업시 주석 해제
+//        Task {
+//             await stepSyncViewModel.syncDailySteps()
+//        }
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/Health/Core/DIContainer/DIContainer+Register.swift
+++ b/Health/Core/DIContainer/DIContainer+Register.swift
@@ -78,6 +78,15 @@ extension DIContainer {
         }
     }
 
+    /// 달력 기반 걸음 수 데이터 조회 서비스를 의존성 주입 컨테이너에 등록합니다.
+    ///
+    /// `CalendarStepService`는 특정 날짜 또는 기간별로 걸음 수 데이터를 조회하고 관리하는 기능을 제공합니다.
+    func registerCalendarStepService() {
+        self.register(.calendarStepService) { _ in
+            return DefaultCalendarStepService()
+        }
+    }
+
     /// 모든 서비스와 ViewModel을 의존성 주입 컨테이너에 일괄 등록합니다.
     ///
     /// 이 메서드는 애플리케이션에서 사용하는 모든 의존성을 올바른 순서로 등록합니다.
@@ -96,5 +105,6 @@ extension DIContainer {
         registerDailyStepViewModel()
         registerGoalStepCountViewModel()
         registerStepSyncViewModel()
+        registerCalendarStepService()
     }
 }

--- a/Health/Core/DIContainer/InjectIdentifier+Keys.swift
+++ b/Health/Core/DIContainer/InjectIdentifier+Keys.swift
@@ -68,4 +68,15 @@ extension InjectIdentifier {
     static var stepSyncViewModel: InjectIdentifier<StepSyncViewModel> {
         InjectIdentifier<StepSyncViewModel>(type: StepSyncViewModel.self)
     }
+
+    /// 달력 기반 걸음 수 데이터 조회 서비스를 식별하는 정적 속성
+    ///
+    /// `CalendarStepService` 프로토콜을 구현하는 서비스들을 의존성 주입 컨테이너에서
+    /// 등록하고 해결할 때 사용되는 타입 안전한 식별자입니다.
+    ///
+    /// - **Returns**: `CalendarStepService` 타입의 `InjectIdentifier` 인스턴스
+    /// - **Note**: 특정 날짜 또는 기간별 걸음 수 데이터 조회에 사용되며, 컴파일 타임에 타입 안전성을 보장합니다.
+    static var calendarStepService: InjectIdentifier<CalendarStepService> {
+        InjectIdentifier<CalendarStepService>(type: CalendarStepService.self)
+    }
 }

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -138,12 +138,7 @@ extension CalendarViewController: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: CalendarMonthCell.id,
-            for: indexPath
-        ) as? CalendarMonthCell else {
-            fatalError("Failed to dequeue CalendarMonthCell")
-        }
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarMonthCell.id, for: indexPath) as! CalendarMonthCell
 
         if let monthData = calendarVM.month(at: indexPath.item) {
             cell.configure(with: monthData)

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -6,6 +6,8 @@ final class CalendarMonthCell: CoreCollectionViewCell {
     @IBOutlet weak var dateCollectionView: UICollectionView!
     @IBOutlet weak var dateCollectionViewHeightConstraint: NSLayoutConstraint!
 
+    @Injected(.calendarStepService) private var stepService: CalendarStepService
+
     private var datesWithBlank: [Date] = []
 
     override func setupAttribute() {
@@ -53,21 +55,13 @@ extension CalendarMonthCell: UICollectionViewDataSource, UICollectionViewDelegat
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: CalendarDateCell.id,
-            for: indexPath
-        ) as? CalendarDateCell else {
-            return UICollectionViewCell()
-        }
-
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarDateCell.id, for: indexPath) as! CalendarDateCell
         let date = datesWithBlank[indexPath.item]
 
         if date == .distantPast || date > Date() {
             cell.configure(date: date, currentSteps: nil, goalSteps: nil)
         } else {
-            // TODO: 실제 걸음 데이터로 수정
-            let current = Int.random(in: 0 ... 15000)
-            let goal = 10000
+            let (current, goal) = stepService.steps(for: date)
             cell.configure(date: date, currentSteps: current, goalSteps: goal)
         }
 

--- a/Health/Services/CalendarStepService/CalendarStepService.swift
+++ b/Health/Services/CalendarStepService/CalendarStepService.swift
@@ -26,8 +26,12 @@ final class DefaultCalendarStepService: CalendarStepService {
         let dailyRequest: NSFetchRequest<DailyStepEntity> = DailyStepEntity.fetchRequest()
         dailyRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", startOfDay as NSDate, endOfDay as NSDate)
 
-        if let daily = try? context.fetch(dailyRequest).first {
-            return (Int(daily.stepCount), Int(daily.goalStepCount))
+        do {
+            if let daily = try context.fetch(dailyRequest).first {
+                return (Int(daily.stepCount), Int(daily.goalStepCount))
+            }
+        } catch {
+            print("CoreData fetch error (DailyStepEntity):", error)
         }
 
         // GoalStepCountEntity 조회 (해당 날짜에 걸음 수 기록이 없을 경우)
@@ -35,8 +39,12 @@ final class DefaultCalendarStepService: CalendarStepService {
         goalRequest.predicate = NSPredicate(format: "effectiveDate <= %@", startOfDay as NSDate)
         goalRequest.sortDescriptors = [NSSortDescriptor(key: "effectiveDate", ascending: false)]
 
-        if let goal = try? context.fetch(goalRequest).first {
-            return (nil, Int(goal.goalStepCount))
+        do {
+            if let goal = try context.fetch(goalRequest).first {
+                return (nil, Int(goal.goalStepCount))
+            }
+        } catch {
+            print("Failed to fetch GoalStepCountEntity: \(error)")
         }
 
         return (nil, nil)

--- a/Health/Services/CalendarStepService/CalendarStepService.swift
+++ b/Health/Services/CalendarStepService/CalendarStepService.swift
@@ -1,0 +1,44 @@
+import CoreData
+import Foundation
+
+/// 달력의 각 날짜별 걸음 수 및 목표 걸음 수를 제공하는 서비스
+///
+/// - 이 서비스는 `DailyStepViewModel` 또는 `GoalStepCountViewModel`을 거치지 않고
+///   **Core Data를 직접 조회**합니다.
+/// - 이유:
+///   1. **최신성 보장**: HealthKit 동기화 직후 또는 더미 데이터 삽입 직후에도 즉시 UI 반영 가능
+///   2. **초기화 타이밍 문제 회피**: ViewModel은 init 시점에 한 번만 fetch를 실행하기 때문에,
+///      데이터 삽입 이후 갱신이 반영되지 않는 경우가 있었음
+///   3. **메모리 효율성**: 달력은 개별 날짜 단위 조회만 필요하므로, 전체 데이터를 캐싱할 필요가 없음
+@MainActor
+protocol CalendarStepService {
+
+    func steps(for date: Date) -> (current: Int?, goal: Int?)
+}
+
+final class DefaultCalendarStepService: CalendarStepService {
+
+    func steps(for date: Date) -> (current: Int?, goal: Int?) {
+        let context = CoreDataStack.shared.viewContext
+        let (startOfDay, endOfDay) = date.rangeOfDay()
+
+        // DailyStepEntity 조회 (해당 날짜의 기록이 있을 경우)
+        let dailyRequest: NSFetchRequest<DailyStepEntity> = DailyStepEntity.fetchRequest()
+        dailyRequest.predicate = NSPredicate(format: "date >= %@ AND date < %@", startOfDay as NSDate, endOfDay as NSDate)
+
+        if let daily = try? context.fetch(dailyRequest).first {
+            return (Int(daily.stepCount), Int(daily.goalStepCount))
+        }
+
+        // GoalStepCountEntity 조회 (해당 날짜에 걸음 수 기록이 없을 경우)
+        let goalRequest: NSFetchRequest<GoalStepCountEntity> = GoalStepCountEntity.fetchRequest()
+        goalRequest.predicate = NSPredicate(format: "effectiveDate <= %@", startOfDay as NSDate)
+        goalRequest.sortDescriptors = [NSSortDescriptor(key: "effectiveDate", ascending: false)]
+
+        if let goal = try? context.fetch(goalRequest).first {
+            return (nil, Int(goal.goalStepCount))
+        }
+
+        return (nil, nil)
+    }
+}


### PR DESCRIPTION
## 작업내용
- `CoreData Entity`로부터 `DefaultCalendarStepService`를 통해 걸음 수 데이터를 달력으로 가져옵니다. (현재는 더미로 테스트)
- 기존에 있는 `DailyStepViewModel`/`GoalStepCountViewModel` 을 경유해서 걸음 수 데이터를 가져오면 초기화 타이밍이 맞지 않아서 CoreData를 직접 조회하도록 합니다.

## 테스트
DEBUG 환경에서 일주일간 생성된 CoreData 더미 엔티티가 보이는지 확인
<img width="300" height="605" alt="image" src="https://github.com/user-attachments/assets/f946671f-ff98-4ff4-9512-5a1e108972f0" />

## 링크
- [노션 태스크](https://www.notion.so/oreumi/CoreData-CalendarStepService-24eebaa8982b8033a80bd3df1dd81c52?source=copy_link)