### PR TITLE
feat/chatbot : 응답값 잘림 이슈 및 SSE 서비스 코드 추가, DIContainer 등록, 네트워크 연결 모니터 설정(리팩토링) 

### DIFF
--- a/Health/Core/DIContainer/InjectIdentifier+Keys.swift
+++ b/Health/Core/DIContainer/InjectIdentifier+Keys.swift
@@ -128,4 +128,8 @@ extension InjectIdentifier {
 	static var privacyService: InjectIdentifier<PrivacyService> {
 		.by(type: PrivacyService.self)
 	}
+	
+	static var chatbotViewModel: InjectIdentifier<ChatbotViewModel> {
+		InjectIdentifier<ChatbotViewModel>(type: ChatbotViewModel.self)
+	}
 }

--- a/Health/Core/Privacy/AddressRegionClassifier.swift
+++ b/Health/Core/Privacy/AddressRegionClassifier.swift
@@ -115,8 +115,6 @@ struct AddressRegionClassifier {
 	/// PrivacyService에서 사용하는 주소 마스킹 처리
 	/// 이 메서드가 주소 마스킹의 메인 진입점입니다.
 	static func findAddressReplacements(in text: String) -> [(NSRange, String)] {
-		print("[AddressClassifier] 입력 텍스트: \(text)")
-		
 		guard let result = detectDetailedAddress(in: text) else {
 			print("[AddressClassifier] 주소를 찾을 수 없음")
 			return []
@@ -146,7 +144,6 @@ struct AddressRegionClassifier {
 				foundProvince = provinceAliases[alias]
 				foundProvinceRange = range
 				originalProvinceText = alias
-				//print("[AddressClassifier] 별칭 매칭: '\(alias)' → '\(foundProvince!)'")
 				break
 			}
 		}
@@ -159,7 +156,6 @@ struct AddressRegionClassifier {
 					foundProvince = db.nameToProvince[key]
 					foundProvinceRange = range
 					originalProvinceText = key
-					//print("[AddressClassifier] JSON 키 매칭: '\(key)' → '\(foundProvince!)'")
 					break
 				}
 			}
@@ -173,7 +169,7 @@ struct AddressRegionClassifier {
 					foundProvince = province
 					foundProvinceRange = range
 					originalProvinceText = province
-					print("🔍 [AddressClassifier] 표준명 매칭: '\(province)'")
+					print("[AddressClassifier] 표준명 매칭: '\(province)'")
 					break
 				}
 			}

--- a/Health/Core/Utils/Concurrency/NCObserverBox.swift
+++ b/Health/Core/Utils/Concurrency/NCObserverBox.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 /// NotificationCenter의 토큰은 Sendable이 아니기 때문에 @Sendable 클로저에서 안전하게 캡처하기 위함
 final class NCObserverBox: @unchecked Sendable {
 	let token: NSObjectProtocol

--- a/Health/Presentation/Chatbot/Chatbot.storyboard
+++ b/Health/Presentation/Chatbot/Chatbot.storyboard
@@ -17,8 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Sjn-mm-DvB">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="704"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Sjn-mm-DvB">
+                                <rect key="frame" x="0.0" y="182" width="393" height="522"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3mU-rj-JGX">
@@ -63,13 +63,23 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pb1-hy-Jgy" customClass="ChatbotHeaderTitleView" customModule="Health" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="118" width="393" height="64"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="64" id="uqz-Fr-Z5Y"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vgf-3o-Tx2"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="pb1-hy-Jgy" firstAttribute="top" secondItem="vgf-3o-Tx2" secondAttribute="top" id="Bcb-LM-NfE"/>
+                            <constraint firstItem="pb1-hy-Jgy" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" id="Grh-5S-6ux"/>
                             <constraint firstItem="3mU-rj-JGX" firstAttribute="bottom" secondItem="vgf-3o-Tx2" secondAttribute="bottom" id="ODB-MH-Tcl"/>
+                            <constraint firstItem="vgf-3o-Tx2" firstAttribute="trailing" secondItem="pb1-hy-Jgy" secondAttribute="trailing" id="R2D-tX-w3g"/>
                             <constraint firstItem="vgf-3o-Tx2" firstAttribute="bottom" secondItem="Sjn-mm-DvB" secondAttribute="bottom" constant="80" id="RqY-8N-hsN"/>
-                            <constraint firstItem="Sjn-mm-DvB" firstAttribute="top" relation="greaterThanOrEqual" secondItem="bIH-9k-yXg" secondAttribute="top" id="eXd-xE-YDp"/>
+                            <constraint firstItem="Sjn-mm-DvB" firstAttribute="top" secondItem="pb1-hy-Jgy" secondAttribute="bottom" id="Zlc-r2-1AD"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" id="ioe-9z-joi"/>
                             <constraint firstItem="vgf-3o-Tx2" firstAttribute="trailing" secondItem="3mU-rj-JGX" secondAttribute="trailing" constant="16" id="kHh-e7-Smv"/>
                             <constraint firstItem="3mU-rj-JGX" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" constant="16" id="oL1-rU-rTT"/>
@@ -81,6 +91,7 @@
                         <outlet property="chattingInputStackView" destination="JcR-5o-DiP" id="lDv-9C-jgs"/>
                         <outlet property="chattingTextField" destination="o50-vy-lbP" id="pDR-5e-edJ"/>
                         <outlet property="containerViewBottomConstraint" destination="ODB-MH-Tcl" id="UcB-4b-CDa"/>
+                        <outlet property="headerView" destination="pb1-hy-Jgy" id="ni0-tM-QuI"/>
                         <outlet property="sendButton" destination="Jhw-LG-ZoI" id="CFe-Za-2Lz"/>
                         <outlet property="tableView" destination="Sjn-mm-DvB" id="kml-mG-8HL"/>
                     </connections>

--- a/Health/Presentation/Chatbot/Chatbot.storyboard
+++ b/Health/Presentation/Chatbot/Chatbot.storyboard
@@ -20,6 +20,11 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Sjn-mm-DvB">
                                 <rect key="frame" x="0.0" y="182" width="393" height="522"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="yZA-Tc-F2L" id="3tM-xM-QRp"/>
+                                    <outlet property="delegate" destination="yZA-Tc-F2L" id="7Kn-cC-fVX"/>
+                                </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3mU-rj-JGX">
                                 <rect key="frame" x="16" y="706.33333333333337" width="361" height="77.666666666666629"/>

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -254,8 +254,6 @@ final class ChatbotViewController: CoreGradientViewController {
 	}
 	
 	private func setupTableView() {
-		tableView.delegate = self
-		tableView.dataSource = self
 		tableView.backgroundColor = .clear
 		tableView.separatorStyle = .none
 		tableView.keyboardDismissMode = .interactive
@@ -785,14 +783,7 @@ final class ChatbotViewController: CoreGradientViewController {
 			tableView.reloadData()
 		}
 	}
-	
-	//	viewDidDisappear에서 cancel처리 함 - Swift 6 경고 이슈로 그렇게 처리함
-	// TODO: 그치만 정말 deinit을 설정하지 않아도 되는 것은 좀 더 검증이 차후 필요할 것 같음.
-	//	deinit {
-	//		NotificationCenter.default.removeObserver(self)
-	//		networkStatusObservationTask?.cancel()
-	//	}
-	
+
 	// URL 생성 유틸 — APIEndpoint.askStreaming 재사용
 	private func buildStreamingURL(content: String, clientID: String) throws -> URL {
 		let endpoint = APIEndpoint.askStreaming(content: content, clientID: clientID)

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -13,9 +13,7 @@ import os
 @MainActor
 final class ChatbotViewController: CoreGradientViewController {
 	// MARK: - Outlets & Dependencies
-	@Injected(default: AlanViewModel()) private var viewModel: AlanViewModel
-	
-	//private let headerView = ChatbotHeaderTitleView()
+	@Injected private var viewModel: ChatbotViewModel
 	private var headerHeight: CGFloat = 64   // 필요시 64~80 조정
 	
 	@IBOutlet weak var headerView: ChatbotHeaderTitleView!
@@ -180,6 +178,16 @@ final class ChatbotViewController: CoreGradientViewController {
 		
 		viewModel.onStreamCompleted = { [weak self] in
 			self?.finishStreamingUI()
+		}
+		
+		viewModel.onError = { [weak self] errorText in
+			guard let self else { return }
+			// 에러 처리: 로딩 셀에 에러 메시지 표시 후 상태 정리
+			Task { @MainActor in
+				self.updateWaitingCellText(errorText)
+				try await Task.sleep(for: .seconds(2))
+				self.cleanupStreamingState()
+			}
 		}
 	}
 

--- a/Health/Presentation/Chatbot/Content/ChatbotContent.swift
+++ b/Health/Presentation/Chatbot/Content/ChatbotContent.swift
@@ -37,3 +37,13 @@ struct ChatMessage {
 		self.timestamp = Date()
 	}
 }
+
+extension MessageType: CustomStringConvertible {
+	var description: String {
+		switch self {
+		case .user: return "user"
+		case .ai: return "ai"
+		case .loading: return "loading"
+		}
+	}
+}

--- a/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.swift
@@ -101,7 +101,6 @@ class AIResponseCell: CoreTableViewCell {
 
 	func configure(with text: String) {
 		if responseTextView.text == text {
-			
 			responseTextView.invalidateIntrinsicContentSize()
 			setNeedsLayout()
 			onContentGrew?()          // 테이블 begin/endUpdates 트리거
@@ -113,7 +112,7 @@ class AIResponseCell: CoreTableViewCell {
 		responseTextView.invalidateIntrinsicContentSize()
 		setNeedsLayout()
 		// 다음 런루프에 contentSize가 업데이트된 뒤 테이블 갱신
-		DispatchQueue.main.async { [weak self] in
+		Task { @MainActor [weak self] in
 			self?.onContentGrew?()
 		}
 	}
@@ -157,7 +156,7 @@ class AIResponseCell: CoreTableViewCell {
 		responseTextView.layoutIfNeeded()
 		
 		// 2) 다음 런루프에서(= contentSize 반영된 뒤) 테이블에게 높이 재계산 요청
-		DispatchQueue.main.async { [weak self] in
+		Task { @MainActor [weak self] in
 			self?.onContentGrew?()
 		}
 	}

--- a/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.swift
@@ -19,30 +19,58 @@ class AIResponseCell: CoreTableViewCell {
 	private var charQueue: [String] = []
 	private(set) var typewriterEnabled = false
 	var charDelayNanos: UInt64 = 40_000_000   // 글자당 지연 40ms 0.04
-	var onContentGrew: (() -> Void)?          // 높이 증가 알림용
-	
+	// MARK: Height update (tableView가 begin/endupdate 할 때)
+	@MainActor var onContentGrew: (() -> Void)?          // 높이 증가 알림용
+	// MARK: KVO
+	private var contentSizeObs: NSKeyValueObservation?
 	
 	override func setupAttribute() {
 		super.setupAttribute()
-
-		selectionStyle = .none
+		
 		responseTextView.textColor = .label
+		responseTextView.backgroundColor = .clear
+		responseTextView.isEditable = false
+		responseTextView.isScrollEnabled = false
+		responseTextView.showsVerticalScrollIndicator = false
+		responseTextView.showsHorizontalScrollIndicator = false
+		
+		// TextContainer 설정 - 텍스트 잘림 방지
 		responseTextView.textContainer.lineFragmentPadding = 0
 		responseTextView.textContainerInset = .zero
-		responseTextView.adjustsFontForContentSizeCategory = true
-		responseTextView.isScrollEnabled = false
+		responseTextView.textContainer.lineBreakMode = .byWordWrapping
+		responseTextView.textContainer.maximumNumberOfLines = 0
 		
-		if #available(iOS 15.0, *) {
-			responseTextView.usesStandardTextScaling = true
+		// 폰트 및 접근성
+		responseTextView.adjustsFontForContentSizeCategory = true
+		if #available(iOS 15.0, *) { responseTextView.usesStandardTextScaling = true }
+		
+		// 우선순위 설정 - 높이는 늘어나고, 너비는 제한
+		responseTextView.setContentCompressionResistancePriority(.required, for: .vertical)
+		responseTextView.setContentHuggingPriority(.defaultLow, for: .vertical)
+		responseTextView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+		responseTextView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+	}
+	
+	override func setupConstraints() {
+		// contentSize 변경될 때마다 테이블 높이 다시 계산됨
+		contentSizeObs?.invalidate()
+		contentSizeObs = responseTextView.observe(\.contentSize, options: [.new]) { [weak self] _, _ in
+			// KVO 콜백은 @Sendable 문맥이므로 메인 액터로 hop
+			Task { @MainActor [weak self] in
+				self?.onContentGrew?()
+			}
 		}
 		
-		setupLeftAlignment()
+		setupWidthConstraints()
 	}
 	
 	override func traitCollectionDidChange(_ previous: UITraitCollection?) {
 		super.traitCollectionDidChange(previous)
 		// 회전/다이내믹 타입 변경 시 최대 너비 재계산
-		setupLeftAlignment()
+		setupWidthConstraints()
+		Task { @MainActor [weak self] in
+			self?.onContentGrew?()
+		}
 	}
 
 	override func prepareForReuse() {
@@ -51,31 +79,43 @@ class AIResponseCell: CoreTableViewCell {
 		typeTask?.cancel()
 		typeTask = nil
 		charQueue.removeAll(keepingCapacity: false)
+		typewriterEnabled = false
+		
+		// KVO 해제
+		contentSizeObs?.invalidate()
+		contentSizeObs = nil
 		
 		responseTextView.text = nil
 	}
 	
-	
-	private func setupLeftAlignment() {
+	private func setupWidthConstraints() {
 		// 디바이스별 최대 너비 설정
 		let maxTextWidth = ChatbotWidthCalculator.maxContentWidth(for: .aiResponseText)
-		textViewWidthConstraint.constant = maxTextWidth
-		textViewTrailingConstraint.priority = .init(750)
-	}
-	
-	func configure(with text: String) {
-		if responseTextView.attributedText?.string == text { return }
 		
-		let attr = NSAttributedString(
-			string: text,
-			attributes: [
-				.foregroundColor: responseTextView.textColor ?? .label,
-				.font: responseTextView.font ?? UIFont.preferredFont(forTextStyle: .body)
-			]
-		)
-		responseTextView.attributedText = attr
+		// Width 제약을 lessThanOrEqualTo로 설정 (고정값 아님)
+		textViewWidthConstraint.constant = maxTextWidth
+		
+		// Trailing 제약 우선순위 낮게 설정
+		textViewTrailingConstraint.priority = UILayoutPriority(750)
+	}
+
+	func configure(with text: String) {
+		if responseTextView.text == text {
+			
+			responseTextView.invalidateIntrinsicContentSize()
+			setNeedsLayout()
+			onContentGrew?()          // 테이블 begin/endUpdates 트리거
+			return
+		}
+		
+		responseTextView.text = text
+		
+		responseTextView.invalidateIntrinsicContentSize()
 		setNeedsLayout()
-		layoutIfNeeded()
+		// 다음 런루프에 contentSize가 업데이트된 뒤 테이블 갱신
+		DispatchQueue.main.async { [weak self] in
+			self?.onContentGrew?()
+		}
 	}
 	
 	// 스트리밍 "조각"이 올 때 호출 — 타자기 모드면 글자 단위로, 아니면 즉시 추가
@@ -97,54 +137,59 @@ class AIResponseCell: CoreTableViewCell {
 			typeTask = nil
 			// 2) 남은 큐를 즉시 붙여서 절대 유실되지 않게
 			if charQueue.isEmpty == false {
-				appendImmediate(charQueue.joined())
+				let remaining = charQueue.joined()
 				charQueue.removeAll(keepingCapacity: false)
+				appendImmediate(remaining)
 			}
 		}
 	}
 
-	
 	// MARK: - 타자기 구현
 	private func appendImmediate(_ piece: String) {
-		let attrs: [NSAttributedString.Key: Any] = [
-			.foregroundColor: responseTextView.textColor ?? .label,
-			.font: responseTextView.font ?? UIFont.preferredFont(forTextStyle: .body)
-		]
-		let storage = responseTextView.textStorage
-		storage.beginEditing()
-		storage.append(NSAttributedString(string: piece, attributes: attrs))
-		storage.endEditing()
-		onContentGrew?()
-		setNeedsLayout()
+		let currentText = responseTextView.text ?? ""
+		responseTextView.text = currentText + piece
+		
+		// 레이아웃 선계산 (붙자마자)
+		responseTextView.invalidateIntrinsicContentSize()
+		responseTextView.layoutManager.allowsNonContiguousLayout = false
+		responseTextView.setNeedsLayout()
+		// 1) 즉시 레이아웃 한 번
+		responseTextView.layoutIfNeeded()
+		
+		// 2) 다음 런루프에서(= contentSize 반영된 뒤) 테이블에게 높이 재계산 요청
+		DispatchQueue.main.async { [weak self] in
+			self?.onContentGrew?()
+		}
 	}
-	
+
 	private func enqueueTypewriter(_ piece: String) {
-		// 한국어 결합 문자도 안전하게 Character 단위로
+		// 문자 단위로 큐에 추가
 		charQueue.append(contentsOf: piece.map { String($0) })
+		
+		// 이미 타이핑 중이면 리턴
 		guard typeTask == nil else { return }
 		
 		typeTask = Task { [weak self] in
 			guard let self else { return }
-			let attrs: [NSAttributedString.Key: Any] = [
-				.foregroundColor: self.responseTextView.textColor ?? .label,
-				.font: self.responseTextView.font ?? UIFont.preferredFont(forTextStyle: .body)
-			]
-			while Task.isCancelled == false {
-				if self.charQueue.isEmpty {
-					self.typeTask = nil
-					break
+			
+			while !Task.isCancelled && !self.charQueue.isEmpty {
+				let char = self.charQueue.removeFirst()
+				
+				// 메인 스레드에서 UI 업데이트
+				await MainActor.run {
+					let currentText = self.responseTextView.text ?? ""
+					self.responseTextView.text = currentText + char
+					self.responseTextView.invalidateIntrinsicContentSize()
+					self.onContentGrew?()
+					self.setNeedsLayout()
 				}
-				let ch = self.charQueue.removeFirst()
-				let storage = self.responseTextView.textStorage
-				storage.beginEditing()
-				storage.append(NSAttributedString(string: ch, attributes: attrs))
-				storage.endEditing()
-				
-				self.onContentGrew?()
-				self.responseTextView.setNeedsLayout()
-				self.setNeedsLayout()
-				
+				// 지연
 				try? await Task.sleep(nanoseconds: self.charDelayNanos)
+			}
+			
+			// 태스크 완료
+			await MainActor.run {
+				self.typeTask = nil
 			}
 		}
 	}
@@ -155,3 +200,5 @@ class AIResponseCell: CoreTableViewCell {
 		charQueue.removeAll(keepingCapacity: false)
 	}
 }
+
+

--- a/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.xib
+++ b/Health/Presentation/Chatbot/Views/Cells/AIResponseCell.xib
@@ -10,15 +10,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="AIResponseCell" rowHeight="215" id="KGk-i7-Jjw" customClass="AIResponseCell" customModule="Health" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="357" height="229"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="AIResponseCell" rowHeight="300" id="KGk-i7-Jjw" customClass="AIResponseCell" customModule="Health" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="357" height="295"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="357" height="229"/>
+                <rect key="frame" x="0.0" y="0.0" width="357" height="295"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GdR-LU-W4w">
-                        <rect key="frame" x="16" y="12" width="310" height="205"/>
+                        <rect key="frame" x="16" y="12" width="310" height="271"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="999" constant="310" id="GyU-zV-8eH"/>
@@ -42,7 +42,7 @@
                 <outlet property="textViewTrailingConstraint" destination="hZ6-Uk-KPX" id="nBk-Ko-XDf"/>
                 <outlet property="textViewWidthConstraint" destination="GyU-zV-8eH" id="ljV-e0-zh6"/>
             </connections>
-            <point key="canvasLocation" x="174.80916030534351" y="29.225352112676056"/>
+            <point key="canvasLocation" x="174.80916030534351" y="52.464788732394368"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleView.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleView.swift
@@ -29,10 +29,10 @@ final class ChatbotHeaderTitleView: CoreView {
 	}()
 	
 	private let closeIconView: UIImageView = {
-		let buttonImage = UIImageView(image: UIImage(systemName: "xmark"))
+		let buttonImage = UIImageView(image: UIImage(systemName: "xmark.circle.fill"))
 		buttonImage.translatesAutoresizingMaskIntoConstraints = false
 		buttonImage.contentMode = .scaleAspectFit
-		buttonImage.tintColor = .accent
+		buttonImage.tintColor = .label
 		return buttonImage
 	}()
 	
@@ -40,7 +40,7 @@ final class ChatbotHeaderTitleView: CoreView {
 		let button = UIButton()
 		button.contentHorizontalAlignment = .center
 		button.contentVerticalAlignment = .center
-		button.tintColor = .accent
+		button.tintColor = .label
 		button.addTarget(self, action: #selector(handleCloseButtonTapped), for: .touchUpInside)
 		button.translatesAutoresizingMaskIntoConstraints = false
 		return button
@@ -90,12 +90,12 @@ final class ChatbotHeaderTitleView: CoreView {
 			
 			closeButton.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -16),
 			closeButton.topAnchor.constraint(equalTo: chatbotImageView.topAnchor),
-			closeButton.widthAnchor.constraint(equalToConstant: 32),
-			closeButton.heightAnchor.constraint(equalToConstant: 32),
+			closeButton.widthAnchor.constraint(equalToConstant: 34),
+			closeButton.heightAnchor.constraint(equalToConstant: 34),
 	
 			closeIconView.centerXAnchor.constraint(equalTo: closeButton.centerXAnchor),
 			closeIconView.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
-			closeIconView.widthAnchor.constraint(equalToConstant: 28),
+			closeIconView.widthAnchor.constraint(equalToConstant: 32),
 			closeIconView.heightAnchor.constraint(equalTo: closeIconView.widthAnchor),
 			
 			bottomAnchor.constraint(greaterThanOrEqualTo: chatbotImageView.bottomAnchor, constant: 12)

--- a/Health/Presentation/Chatbot/Views/Cells/LoadingResponseCell.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/LoadingResponseCell.swift
@@ -19,7 +19,7 @@ final class LoadingResponseCell: CoreTableViewCell {
 	private let messageLabel: UILabel = {
 		let lb = UILabel()
 		lb.translatesAutoresizingMaskIntoConstraints = false
-		lb.text = ""
+		lb.text = "응답을 생성하고 있습니다.."
 		lb.textColor = .secondaryLabel
 		lb.font = .preferredFont(forTextStyle: .callout)
 		lb.numberOfLines = 0

--- a/Health/Services/NetworkService/AlanSSEClient.swift
+++ b/Health/Services/NetworkService/AlanSSEClient.swift
@@ -300,13 +300,6 @@ extension AlanSSEClient: URLSessionDataDelegate {
 	}
 
 	func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-		//		if let error {
-		//			Log.net.error("didCompleteWithError: \(String(describing: error), privacy: .public)")
-		//			continuation?.finish(throwing: error)
-		//		} else {
-		//			Log.net.info("server closed without error")
-		//		}
-		//		disconnect()
 		if error == nil, byteBuffer.isEmpty == false {
 			if let tail = String(data: byteBuffer, encoding: .utf8)
 				?? String(data: byteBuffer, encoding: .ascii) {
@@ -326,7 +319,5 @@ extension AlanSSEClient: URLSessionDataDelegate {
 		
 		if let error { continuation?.finish(throwing: error) }
 		else { continuation?.finish() }
-		
-		//disconnect()
 	}
 }

--- a/Health/Services/NetworkService/SSEService/AlanSSEClient.swift
+++ b/Health/Services/NetworkService/SSEService/AlanSSEClient.swift
@@ -47,14 +47,14 @@ enum AlanSSEClientError: Error, LocalizedError {
 	var errorDescription: String? {
 		switch self {
 		case .badHTTPStatus(let code):   return "SSE HTTP 상태코드 오류: \(code)"
-		case .badContentType(let ct):    return "SSE Content-Type이 올바르지 않음: \(ct)"
+		case .badContentType(let contentType):    return "SSE Content-Type이 올바르지 않음: \(contentType)"
 		}
 	}
 }
 
 private let log = Logger(subsystem: "Health", category: "SSE")
 
-final class AlanSSEClient: NSObject {
+final class AlanSSEClient: NSObject, AlanSSEClientProtocol {
 	private var session: URLSession?
 	private var task: URLSessionDataTask?
 
@@ -62,8 +62,7 @@ final class AlanSSEClient: NSObject {
 	private var continuation: Stream.Continuation?
 
 	private var byteBuffer = Data()
-	private let newline2 = Data("\n\n".utf8)
-	
+
 	private lazy var decoder = JSONDecoder() // 재사용
 
 	func connect(url: URL) -> Stream {
@@ -93,9 +92,6 @@ final class AlanSSEClient: NSObject {
 		req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
 
 		Log.net.info("SSE connect -> \(url.absoluteString, privacy: .public)")
-		if let headers = cfg.httpAdditionalHeaders {
-			Log.net.debug("headers: \(String(describing: headers), privacy: .public)")
-		}
 
 		task = session?.dataTask(with: req)
 		task?.resume()
@@ -112,108 +108,13 @@ final class AlanSSEClient: NSObject {
 		byteBuffer.removeAll(keepingCapacity: false)
 	}
 	
-	private func decodeEvent(_ json: String) throws -> AlanStreamingResponse {
-		if let data = json.data(using: .utf8) {
-			if let dto = try? decoder.decode(AlanStreamingResponse.self, from: data) { return dto }
-		}
-		// '{'type':'...'..}' 패턴이면 한 번만 보정
-		if json.contains("'}") || json.contains("':") {
-			let fixed = json
-				.replacingOccurrences(of: #"'([A-Za-z0-9_]+)'\s*:"#,
-									  with: #""$1":"#,
-									  options: .regularExpression)
-				.replacingOccurrences(of: #":\s*'([^']*)'"#,
-									  with: #": "$1""#,
-									  options: .regularExpression)
-			if let data = fixed.data(using: .utf8),
-			   let dto  = try? decoder.decode(AlanStreamingResponse.self, from: data) {
-				return dto
-			}
-		}
-		throw NSError(domain: "SSE", code: -10, userInfo: [NSLocalizedDescriptionKey:"decode fail"])
-	}
-	/// 서버가 싱글쿼트로 보내는 payload에서 type/speak/content만 안전 추출
-	private func fallbackParsePseudoJSON(_ s: String) -> AlanStreamingResponse? {
-		func match(_ pattern: String) -> String? {
-			let regex = try! NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators])
-			guard let m = regex.firstMatch(in: s, options: [], range: NSRange(location: 0, length: (s as NSString).length)),
-				  m.numberOfRanges >= 2 else { return nil }
-			return (s as NSString).substring(with: m.range(at: 1))
-		}
-
-		guard let typeStr = match(#"type':\s*'([^']+)'"#) else { return nil }
-		
-		// content와 speak 둘 다 시도
-		let rawContent = match(#"content':\s*'(.*)'\s*}\s*}"#)
-		let rawSpeak   = match(#"speak':\s*'(.*)'\s*}\s*}"#)
-
-		// 치환: \n -> 실제 개행
-		func normalize(_ t: String?) -> String? {
-			t?.replacingOccurrences(of: #"\\n"#, with: "\n")
-		}
-
-		let type = AlanStreamingResponse.StreamingType(rawValue: typeStr) ?? .continue
-		let dto  = AlanStreamingResponse(
-			type: type,
-			data: .init(content: normalize(rawContent) ?? normalize(rawSpeak),
-						speak: normalize(rawSpeak))
-		)
-		//Log.sse.info("fallback parsed type=\(type.rawValue, privacy: .public) len=\((dto.data.content ?? "").count, privacy: .public)")
-		return dto
-	}
-	
-	private func coerceSingleQuotedJSON(_ raw: String) -> String {
-		// 1) 키:   '{'type': 'continue', 'data': {...}}'  의 'type', 'data' -> "type", "data"
-		var fixed = raw.replacingOccurrences(
-			of: #"'([A-Za-z0-9_]+)'\s*:"#,
-			with: #""$1":"#,
-			options: .regularExpression
-		)
-		// 2) 값:   ": '...'"  -> ": "..."    (문장 안의 U+2018/2019(‘ ’)는 건드리지 않음)
-		fixed = fixed.replacingOccurrences(
-			of: #":\s*'([^']*)'"#,
-			with: #": "$1""#,
-			options: .regularExpression
-		)
-		return fixed
-	}
-
-	/// 한 개의 SSE data 블록 문자열을 AlanStreamingResponse로 파싱
-	private func decodeSSEJSON(_ jsonString: String) throws -> AlanStreamingResponse {
-		guard jsonString.isEmpty == false else { throw SSEParseError.emptyData }
-
-		// 0) 원본 미리보기 로그
-		let preview = jsonString.prefix(120)
-		log.debug("block json preview=\(String(preview), privacy: .public)")
-
-		// 1) 그대로 디코드 시도
-		if let data = jsonString.data(using: .utf8) {
-			do {
-				let dto = try JSONDecoder().decode(AlanStreamingResponse.self, from: data)
-				return dto
-			} catch {
-				print(error)
-				//log.debug("direct decode failed: \(String(describing: error), privacy: .public)")
-			}
-		}
-
-		// 2) 싱글쿼트 -> 유효 JSON으로 보정 후 재시도
-		let fixed = coerceSingleQuotedJSON(jsonString)
-		//log.debug("fixed json preview=\(String(fixedPreview), privacy: .public)")
-
-		guard let fixedData = fixed.data(using: .utf8) else { throw SSEParseError.badJSON }
-		do {
-			let dto = try JSONDecoder().decode(AlanStreamingResponse.self, from: fixedData)
-			return dto
-		} catch {
-			log.error("decode failed even after fix: \(String(describing: error), privacy: .public)")
-			throw error
-		}
+	deinit {
+		task?.cancel()
+		session?.invalidateAndCancel()
 	}
 }
 
 extension AlanSSEClient: URLSessionDataDelegate {
-
 	//HTTP 상태/헤더 확인
 	func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
 					didReceive response: URLResponse,
@@ -289,7 +190,7 @@ extension AlanSSEClient: URLSessionDataDelegate {
 			
 			let json = datas.joined(separator: "\n")
 			do {
-				let dto = try decodeEvent(json)
+				let dto = try AlanSSEParser.decodeEvent(json)
 				continuation?.yield(dto)
 				if dto.type == .complete { continuation?.finish() }
 			} catch {
@@ -298,7 +199,7 @@ extension AlanSSEClient: URLSessionDataDelegate {
 			}
 		}
 	}
-
+	
 	func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
 		if error == nil, byteBuffer.isEmpty == false {
 			if let tail = String(data: byteBuffer, encoding: .utf8)
@@ -310,14 +211,17 @@ extension AlanSSEClient: URLSessionDataDelegate {
 				}
 				if datas.isEmpty == false {
 					let json = datas.joined(separator: "\n")
-					if let dto = try? decodeEvent(json) {
+					if let dto = try? AlanSSEParser.decodeEvent(json) {
 						continuation?.yield(dto)
 					}
 				}
 			}
 		}
 		
-		if let error { continuation?.finish(throwing: error) }
-		else { continuation?.finish() }
+		if let error {
+			continuation?.finish(throwing: error)
+		} else {
+			continuation?.finish()
+		}
 	}
 }

--- a/Health/Services/NetworkService/SSEService/AlanSSEParser.swift
+++ b/Health/Services/NetworkService/SSEService/AlanSSEParser.swift
@@ -1,0 +1,74 @@
+//
+//  AlanSSEParser.swift
+//  Health
+//
+//  Created by Seohyun Kim on 8/19/25.
+//
+
+import Foundation
+
+/// SSE `data:` 페이로드(JSON 텍스트)를 AlanStreamingResponse로 디코딩.
+/// 서버가 싱글쿼트를 섞는 등 비표준 JSON을 보낼 경우를 보정.
+enum AlanSSEParser {
+	/// 일반 디코딩 → 실패 시 싱글쿼트/키 보정 후 재시도
+	static func decodeEvent(_ json: String,
+							using decoder: JSONDecoder = JSONDecoder()) throws -> AlanStreamingResponse {
+		if let data = json.data(using: .utf8),
+		   let dto = try? decoder.decode(AlanStreamingResponse.self, from: data) {
+			return dto
+		}
+		let fixed = coerceSingleQuotedJSON(json)
+		guard let fixedData = fixed.data(using: .utf8) else {
+			throw NSError(domain: "SSE",
+						  code: -10,
+						  userInfo: [NSLocalizedDescriptionKey:"invalid encoding"])
+		}
+		return try decoder.decode(AlanStreamingResponse.self, from: fixedData)
+	}
+	
+	/// '{'type':'continue', 'data':{...}}' → {"type":"continue","data":{...}}
+	static func coerceSingleQuotedJSON(_ raw: String) -> String {
+		var fixed = raw.replacingOccurrences(
+			of: #"'([A-Za-z0-9_]+)'\s*:"#,
+			with: #""$1":"#,
+			options: .regularExpression
+		)
+		fixed = fixed.replacingOccurrences(
+			of: #":\s*'([^']*)'"#,
+			with: #": "$1""#,
+			options: .regularExpression
+		)
+		return fixed
+	}
+	
+	// 필요 시 살려두는 옵션(현재 미사용): 싱글쿼트 기반 pseudo-JSON fallback 파싱
+	/// 서버가 싱글쿼트로 보내는 payload에서 type/speak/content만 안전 추출
+	private func fallbackParsePseudoJSON(_ s: String) -> AlanStreamingResponse? {
+		func match(_ pattern: String) -> String? {
+			let regex = try! NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators])
+			guard let m = regex.firstMatch(in: s, options: [], range: NSRange(location: 0, length: (s as NSString).length)),
+				  m.numberOfRanges >= 2 else { return nil }
+			return (s as NSString).substring(with: m.range(at: 1))
+		}
+		
+		guard let typeStr = match(#"type':\s*'([^']+)'"#) else { return nil }
+		
+		// content와 speak 둘 다 시도
+		let rawContent = match(#"content':\s*'(.*)'\s*}\s*}"#)
+		let rawSpeak   = match(#"speak':\s*'(.*)'\s*}\s*}"#)
+		
+		// 치환: \n -> 실제 개행
+		func normalize(_ t: String?) -> String? {
+			t?.replacingOccurrences(of: #"\\n"#, with: "\n")
+		}
+		
+		let type = AlanStreamingResponse.StreamingType(rawValue: typeStr) ?? .continue
+		let dto  = AlanStreamingResponse(
+			type: type,
+			data: .init(content: normalize(rawContent) ?? normalize(rawSpeak),
+						speak: normalize(rawSpeak))
+		)
+		//Log.sse.info("fallback parsed type=\(type.rawValue, privacy: .public) len=\((dto.data.content ?? "").count, privacy: .public)")
+		return dto
+	}
+}

--- a/Health/Services/NetworkService/SSEService/AlanSSEService.swift
+++ b/Health/Services/NetworkService/SSEService/AlanSSEService.swift
@@ -1,0 +1,55 @@
+//
+//  AlanSSEService.swift
+//  Health
+//
+//  Created by Seohyun Kim on 8/19/25.
+//
+
+import Foundation
+
+final class AlanSSEService: AlanSSEServiceProtocol {
+
+	private let client: AlanSSEClientProtocol
+	
+	init(client: AlanSSEClientProtocol) {
+		self.client = client
+	}
+	// NOTE: clientID는 resetState 호출에 의해 변경될 수 있으므로, 항상 최신 상태로 반영하기 위해 계산 프로퍼티로 유지
+	// server 에러와 사용자의 요청값 history reset해 응답값 정확성 높이기 위함
+	private var clientID: String { AppConfiguration.clientID }
+	
+	/// Alan SSE 스트리밍 응답을 비동기 에러 가능한 스트림으로 제공합니다.
+	/// - Parameter content: 사용자 메시지
+	/// - Returns: `AsyncThrowingStream<AlanStreamingResponse, Error>`
+	
+	func stream(content: String) throws -> AsyncThrowingStream<AlanStreamingResponse, any Error> {
+		let masked = PrivacyService.maskSensitiveInfo(in: content)
+		let url = try buildStreamingURL(content: masked)
+		let rawStream = client.connect(url: url)
+		
+		return AsyncThrowingStream { continuation in
+			Task {
+				do {
+					streamLoop: for try await event in rawStream {
+						continuation.yield(event)
+						if event.type == .complete { break streamLoop }
+					}
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+		}
+	}
+	
+	private func buildStreamingURL(content: String) throws -> URL {
+		let endpoint = APIEndpoint.askStreaming(content: content, clientID: clientID)
+		var comps = URLComponents(
+			url: endpoint.baseURL.appendingPathComponent(endpoint.path),
+			resolvingAgainstBaseURL: false
+		)
+		comps?.queryItems = endpoint.queryItems
+		guard let url = comps?.url else { throw NetworkError.badURL }
+		return url
+	}
+}

--- a/Health/Services/NetworkService/SSEService/Protocol/AlanSSEClientProtocol.swift
+++ b/Health/Services/NetworkService/SSEService/Protocol/AlanSSEClientProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AlanSSEClientProtocol.swift
+//  Health
+//
+//  Created by Seohyun Kim on 8/19/25.
+//
+
+import Foundation
+
+protocol AlanSSEClientProtocol {
+	func connect(url: URL) -> AsyncThrowingStream<AlanStreamingResponse, Error>
+	func disconnect()
+}

--- a/Health/Services/NetworkService/SSEService/Protocol/AlanSSEServiceProtocol.swift
+++ b/Health/Services/NetworkService/SSEService/Protocol/AlanSSEServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  AlanSSEServiceProtocol.swift
+//  Health
+//
+//  Created by Seohyun Kim on 8/19/25.
+//
+
+import Foundation
+
+protocol AlanSSEServiceProtocol {
+	func stream(content: String) throws -> AsyncThrowingStream<AlanStreamingResponse, Error>
+}

--- a/Health/ViewModels/AlanViewModel.swift
+++ b/Health/ViewModels/AlanViewModel.swift
@@ -12,11 +12,6 @@ final class AlanViewModel {
 	}
 	
 	var didReceiveResponseText: ((String) -> Void)?
-	//  MARK: 스트리밍용 콜백 (조각, 완료, 에러)
-//	var onStreamChunk: ((String) -> Void)?
-//	var onStreamCompleted: (() -> Void)?
-//	var onActionText: ((String) -> Void)?
-	//private var sseClient: AlanSSEClient?
 	
 	// MARK: - 일반 질문 형식 APIEndpoint
 	func sendQuestion(_ content: String) async -> String? {
@@ -33,84 +28,6 @@ final class AlanViewModel {
 		}
 	}
 	
-	// MARK: SSE Streaming 형식의 응답을 받는 질문 요청
-//	func startStreamingQuestion(_ content: String) {
-//#if DEBUG
-//		// ── Debug: 로컬 목 JSON을 “한 글자씩” 흘려서 SSE처럼 보이게
-//		Task { @MainActor [weak self] in
-//			guard let self else { return }
-//			defer { self.onStreamCompleted?() }
-//			
-//			struct Mock: Decodable {
-//				struct Action: Decodable { let name: String; let speak: String }
-//				let action: Action
-//				let content: String
-//			}
-//			
-//			do {
-//				guard let url = Bundle.main.url(forResource: "mock_ask_response", withExtension: "json") else {
-//					self.onActionText?("모킹 파일을 찾을 수 없어요.")
-//					return
-//				}
-//				let data = try Data(contentsOf: url)
-//				let mock = try JSONDecoder().decode(Mock.self, from: data)
-//				
-//				if mock.action.speak.isEmpty == false {
-//					self.onActionText?(mock.action.speak)
-//				}
-//				
-//				// 실제 SSE 느낌: 20~40ms 간격으로 한 글자씩
-//				for ch in mock.content {
-//					try await Task.sleep(nanoseconds: 30_000_000)
-//					self.onStreamChunk?(String(ch))
-//				}
-//			} catch {
-//				self.errorMessage = error.localizedDescription
-//			}
-//		}
-//		#else
-//		// ── Release: 실제 SSE
-//		do {
-//			let safe = PrivacyService.maskSensitiveInfo(in: content)
-//			let url = try buildStreamingURL(content: safe, clientID: clientID)
-//			let client = AlanSSEClient()
-//			self.sseClient = client
-//			
-//			let stream = client.connect(url: url)
-//			Task { @MainActor [weak self]  in
-//				guard let self else { return }
-//				defer {
-//					self.sseClient?.disconnect()
-//					self.sseClient = nil
-//					self.onStreamCompleted?()
-//				}
-//				
-//				do {
-//					streamLoop: for try await event in stream {
-//						switch event.type {
-//						case .action:
-//							if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
-//								self.onActionText?(speak)
-//							}
-//						case .continue:
-//							if let piece = event.data.content, !piece.isEmpty {
-//								self.onStreamChunk?(piece)
-//							}
-//						case .complete:
-//							break streamLoop
-//						}
-//					}
-//				} catch {
-//					self.errorMessage = error.localizedDescription
-//				}
-//			}
-//		} catch {
-//			self.errorMessage = error.localizedDescription
-//			self.onStreamCompleted?()
-//		}
-//		#endif
-//	}
-	
 	func resetAgentState() async {
 		let endpoint = APIEndpoint.resetState(clientID: clientID)
 		
@@ -121,81 +38,6 @@ final class AlanViewModel {
 			errorMessage = error.localizedDescription
 		}
 	}
-	
-	// MARK: - SSE 요청 중 Server Error 500 이 뜰 때 reset State
-//	func startStreamingQuestionWithAutoReset(_ content: String) {
-//#if DEBUG
-//		// Debug 모드에서는 mock 데이터 사용
-//		startStreamingQuestion(content)
-//#else
-//		// Release 모드에서는 실제 SSE + 자동 재시도 로직
-//		Task { @MainActor [weak self] in
-//			guard let self else { return }
-//			await self._startStreaming(content: content, canRetry: true)
-//		}
-//#endif
-//	}
-
-	/*
-	 private func _startStreaming(content: String, canRetry: Bool) async {
-		 var shouldCallCompleted = true
-		 do {
-			 let safe = PrivacyService.maskSensitiveInfo(in: content)
-			 let url = try buildStreamingURL(content: safe, clientID: clientID)
-			 let client = AlanSSEClient()
-			 self.sseClient = client
-			 
-			 let stream = client.connect(url: url)
-			 defer {
-				 self.sseClient?.disconnect()
-				 self.sseClient = nil
-				 if shouldCallCompleted {
-					 self.onStreamCompleted?()
-				 }
-			 }
-			 
-			 streamLoop: for try await event in stream {
-				 switch event.type {
-				 case .action:
-					 if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
-						 self.onActionText?(speak)
-					 }
-				 case .continue:
-					 if let piece = event.data.content, !piece.isEmpty {
-						 self.onStreamChunk?(piece)
-					 }
-				 case .complete:
-					 break streamLoop
-				 }
-			 }
-		 } catch {
-			 // 복구 가능한 경우: reset 후 1회 재시도
-			 let recoverable: Bool = {
-				 if let e = error as? AlanSSEClientError {
-					 switch e {
-					 case .badHTTPStatus(let code): return code == 500
-					 case .badContentType: return true
-					 }
-				 }
-				 return false
-			 }()
-			 
-			 if recoverable, canRetry {
-				 // 진행 멘트(옵션)
-				 shouldCallCompleted = false
-				 self.onActionText?("세션을 초기화하고 다시 시도 중…")
-				 await self.resetAgentState() // DELETE /api/v1/reset-state (문서 확인)
-				 try? await Task.sleep(nanoseconds: 300_000_000)
-				 await self._startStreaming(content: content, canRetry: false)
-				 return
-			 }
-			 
-			 self.errorMessage = error.localizedDescription
-			 //self.onStreamCompleted?()
-		 }
-	 }
-	 
-	 */
 }
 
 extension AlanViewModel {

--- a/Health/ViewModels/AlanViewModel.swift
+++ b/Health/ViewModels/AlanViewModel.swift
@@ -13,10 +13,10 @@ final class AlanViewModel {
 	
 	var didReceiveResponseText: ((String) -> Void)?
 	//  MARK: 스트리밍용 콜백 (조각, 완료, 에러)
-	var onStreamChunk: ((String) -> Void)?
-	var onStreamCompleted: (() -> Void)?
-	var onActionText: ((String) -> Void)?
-	private var sseClient: AlanSSEClient?
+//	var onStreamChunk: ((String) -> Void)?
+//	var onStreamCompleted: (() -> Void)?
+//	var onActionText: ((String) -> Void)?
+	//private var sseClient: AlanSSEClient?
 	
 	// MARK: - 일반 질문 형식 APIEndpoint
 	func sendQuestion(_ content: String) async -> String? {
@@ -34,82 +34,82 @@ final class AlanViewModel {
 	}
 	
 	// MARK: SSE Streaming 형식의 응답을 받는 질문 요청
-	func startStreamingQuestion(_ content: String) {
-#if DEBUG
-		// ── Debug: 로컬 목 JSON을 “한 글자씩” 흘려서 SSE처럼 보이게
-		Task { @MainActor [weak self] in
-			guard let self else { return }
-			defer { self.onStreamCompleted?() }
-			
-			struct Mock: Decodable {
-				struct Action: Decodable { let name: String; let speak: String }
-				let action: Action
-				let content: String
-			}
-			
-			do {
-				guard let url = Bundle.main.url(forResource: "mock_ask_response", withExtension: "json") else {
-					self.onActionText?("모킹 파일을 찾을 수 없어요.")
-					return
-				}
-				let data = try Data(contentsOf: url)
-				let mock = try JSONDecoder().decode(Mock.self, from: data)
-				
-				if mock.action.speak.isEmpty == false {
-					self.onActionText?(mock.action.speak)
-				}
-				
-				// 실제 SSE 느낌: 20~40ms 간격으로 한 글자씩
-				for ch in mock.content {
-					try await Task.sleep(nanoseconds: 30_000_000)
-					self.onStreamChunk?(String(ch))
-				}
-			} catch {
-				self.errorMessage = error.localizedDescription
-			}
-		}
-		#else
-		// ── Release: 실제 SSE
-		do {
-			let safe = PrivacyService.maskSensitiveInfo(in: content)
-			let url = try buildStreamingURL(content: safe, clientID: clientID)
-			let client = AlanSSEClient()
-			self.sseClient = client
-			
-			let stream = client.connect(url: url)
-			Task { @MainActor [weak self]  in
-				guard let self else { return }
-				defer {
-					self.sseClient?.disconnect()
-					self.sseClient = nil
-					self.onStreamCompleted?()
-				}
-				
-				do {
-					streamLoop: for try await event in stream {
-						switch event.type {
-						case .action:
-							if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
-								self.onActionText?(speak)
-							}
-						case .continue:
-							if let piece = event.data.content, !piece.isEmpty {
-								self.onStreamChunk?(piece)
-							}
-						case .complete:
-							break streamLoop
-						}
-					}
-				} catch {
-					self.errorMessage = error.localizedDescription
-				}
-			}
-		} catch {
-			self.errorMessage = error.localizedDescription
-			self.onStreamCompleted?()
-		}
-		#endif
-	}
+//	func startStreamingQuestion(_ content: String) {
+//#if DEBUG
+//		// ── Debug: 로컬 목 JSON을 “한 글자씩” 흘려서 SSE처럼 보이게
+//		Task { @MainActor [weak self] in
+//			guard let self else { return }
+//			defer { self.onStreamCompleted?() }
+//			
+//			struct Mock: Decodable {
+//				struct Action: Decodable { let name: String; let speak: String }
+//				let action: Action
+//				let content: String
+//			}
+//			
+//			do {
+//				guard let url = Bundle.main.url(forResource: "mock_ask_response", withExtension: "json") else {
+//					self.onActionText?("모킹 파일을 찾을 수 없어요.")
+//					return
+//				}
+//				let data = try Data(contentsOf: url)
+//				let mock = try JSONDecoder().decode(Mock.self, from: data)
+//				
+//				if mock.action.speak.isEmpty == false {
+//					self.onActionText?(mock.action.speak)
+//				}
+//				
+//				// 실제 SSE 느낌: 20~40ms 간격으로 한 글자씩
+//				for ch in mock.content {
+//					try await Task.sleep(nanoseconds: 30_000_000)
+//					self.onStreamChunk?(String(ch))
+//				}
+//			} catch {
+//				self.errorMessage = error.localizedDescription
+//			}
+//		}
+//		#else
+//		// ── Release: 실제 SSE
+//		do {
+//			let safe = PrivacyService.maskSensitiveInfo(in: content)
+//			let url = try buildStreamingURL(content: safe, clientID: clientID)
+//			let client = AlanSSEClient()
+//			self.sseClient = client
+//			
+//			let stream = client.connect(url: url)
+//			Task { @MainActor [weak self]  in
+//				guard let self else { return }
+//				defer {
+//					self.sseClient?.disconnect()
+//					self.sseClient = nil
+//					self.onStreamCompleted?()
+//				}
+//				
+//				do {
+//					streamLoop: for try await event in stream {
+//						switch event.type {
+//						case .action:
+//							if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
+//								self.onActionText?(speak)
+//							}
+//						case .continue:
+//							if let piece = event.data.content, !piece.isEmpty {
+//								self.onStreamChunk?(piece)
+//							}
+//						case .complete:
+//							break streamLoop
+//						}
+//					}
+//				} catch {
+//					self.errorMessage = error.localizedDescription
+//				}
+//			}
+//		} catch {
+//			self.errorMessage = error.localizedDescription
+//			self.onStreamCompleted?()
+//		}
+//		#endif
+//	}
 	
 	func resetAgentState() async {
 		let endpoint = APIEndpoint.resetState(clientID: clientID)
@@ -123,76 +123,79 @@ final class AlanViewModel {
 	}
 	
 	// MARK: - SSE 요청 중 Server Error 500 이 뜰 때 reset State
-	func startStreamingQuestionWithAutoReset(_ content: String) {
-#if DEBUG
-		// Debug 모드에서는 mock 데이터 사용
-		startStreamingQuestion(content)
-#else
-		// Release 모드에서는 실제 SSE + 자동 재시도 로직
-		Task { @MainActor [weak self] in
-			guard let self else { return }
-			await self._startStreaming(content: content, canRetry: true)
-		}
-#endif
-	}
+//	func startStreamingQuestionWithAutoReset(_ content: String) {
+//#if DEBUG
+//		// Debug 모드에서는 mock 데이터 사용
+//		startStreamingQuestion(content)
+//#else
+//		// Release 모드에서는 실제 SSE + 자동 재시도 로직
+//		Task { @MainActor [weak self] in
+//			guard let self else { return }
+//			await self._startStreaming(content: content, canRetry: true)
+//		}
+//#endif
+//	}
 
-	private func _startStreaming(content: String, canRetry: Bool) async {
-		var shouldCallCompleted = true
-		do {
-			let safe = PrivacyService.maskSensitiveInfo(in: content)
-			let url = try buildStreamingURL(content: safe, clientID: clientID)
-			let client = AlanSSEClient()
-			self.sseClient = client
-			
-			let stream = client.connect(url: url)
-			defer {
-				self.sseClient?.disconnect()
-				self.sseClient = nil
-				if shouldCallCompleted {
-					self.onStreamCompleted?()
-				}
-			}
-			
-			streamLoop: for try await event in stream {
-				switch event.type {
-				case .action:
-					if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
-						self.onActionText?(speak)
-					}
-				case .continue:
-					if let piece = event.data.content, !piece.isEmpty {
-						self.onStreamChunk?(piece)
-					}
-				case .complete:
-					break streamLoop
-				}
-			}
-		} catch {
-			// 복구 가능한 경우: reset 후 1회 재시도
-			let recoverable: Bool = {
-				if let e = error as? AlanSSEClientError {
-					switch e {
-					case .badHTTPStatus(let code): return code == 500
-					case .badContentType: return true
-					}
-				}
-				return false
-			}()
-			
-			if recoverable, canRetry {
-				// 진행 멘트(옵션)
-				shouldCallCompleted = false
-				self.onActionText?("세션을 초기화하고 다시 시도 중…")
-				await self.resetAgentState() // DELETE /api/v1/reset-state (문서 확인)
-				try? await Task.sleep(nanoseconds: 300_000_000)
-				await self._startStreaming(content: content, canRetry: false)
-				return
-			}
-			
-			self.errorMessage = error.localizedDescription
-			//self.onStreamCompleted?()
-		}
-	}
+	/*
+	 private func _startStreaming(content: String, canRetry: Bool) async {
+		 var shouldCallCompleted = true
+		 do {
+			 let safe = PrivacyService.maskSensitiveInfo(in: content)
+			 let url = try buildStreamingURL(content: safe, clientID: clientID)
+			 let client = AlanSSEClient()
+			 self.sseClient = client
+			 
+			 let stream = client.connect(url: url)
+			 defer {
+				 self.sseClient?.disconnect()
+				 self.sseClient = nil
+				 if shouldCallCompleted {
+					 self.onStreamCompleted?()
+				 }
+			 }
+			 
+			 streamLoop: for try await event in stream {
+				 switch event.type {
+				 case .action:
+					 if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
+						 self.onActionText?(speak)
+					 }
+				 case .continue:
+					 if let piece = event.data.content, !piece.isEmpty {
+						 self.onStreamChunk?(piece)
+					 }
+				 case .complete:
+					 break streamLoop
+				 }
+			 }
+		 } catch {
+			 // 복구 가능한 경우: reset 후 1회 재시도
+			 let recoverable: Bool = {
+				 if let e = error as? AlanSSEClientError {
+					 switch e {
+					 case .badHTTPStatus(let code): return code == 500
+					 case .badContentType: return true
+					 }
+				 }
+				 return false
+			 }()
+			 
+			 if recoverable, canRetry {
+				 // 진행 멘트(옵션)
+				 shouldCallCompleted = false
+				 self.onActionText?("세션을 초기화하고 다시 시도 중…")
+				 await self.resetAgentState() // DELETE /api/v1/reset-state (문서 확인)
+				 try? await Task.sleep(nanoseconds: 300_000_000)
+				 await self._startStreaming(content: content, canRetry: false)
+				 return
+			 }
+			 
+			 self.errorMessage = error.localizedDescription
+			 //self.onStreamCompleted?()
+		 }
+	 }
+	 
+	 */
 }
 
 extension AlanViewModel {

--- a/Health/ViewModels/ChatbotViewModel.swift
+++ b/Health/ViewModels/ChatbotViewModel.swift
@@ -1,0 +1,214 @@
+//
+//  ChatbotViewModel.swift
+//  Health
+//
+//  Created by Nat Kim on 8/19/25.
+//
+
+import Foundation
+
+/// 챗봇 기능 전용 Alan SSE 스트리밍 전용, 챗봇 프롬프트 관리 ViewModel.
+/// - NOTE: 일반 질의/리셋은 AlanViewModel이 담당.
+/// - NOTE: 서비스/클라이언트는 프로토콜에 의존해 테스트/모킹이 쉬움.
+@MainActor
+final class ChatbotViewModel {
+	@Injected private var sseService: AlanSSEServiceProtocol
+	@Injected private var networkService: NetworkService
+	
+	var onActionText: ((String) -> Void)?
+	var onStreamChunk: ((String) -> Void)?
+	var onStreamCompleted: (() -> Void)?
+	var onError: ((String) -> Void)?
+	
+	private var streamTask: Task<Void, Never>?
+	private var clientID: String { AppConfiguration.clientID }
+	
+	deinit { streamTask?.cancel() }
+	
+	// 단순 스트리밍
+	func startStreamingQuestion(_ content: String, autoReset: Bool = true) {
+		streamTask?.cancel()
+		streamTask = Task { [weak self] in
+			guard let self else { return }
+			await self._startStreaming(content: content, canRetry: autoReset)
+		}
+	}
+	
+	/// 서버 500 등 복구 가능 오류 시 1회 reset 후 재시도
+	func startStreamingQuestionWithAutoReset(_ content: String) {
+		streamTask?.cancel()
+#if DEBUG
+		startMockStreaming(content)
+#else
+		streamTask = Task { [weak self] in
+			guard let self else { return }
+			await self._startStreaming(content: content, canRetry: true)
+		}
+#endif
+	}
+	
+	private func _startStreaming(content: String, canRetry: Bool) async {
+		var callComplete = true
+		defer { if callComplete { onStreamCompleted?() } }
+		
+		do {
+			let stream = try sseService.stream(content: content)
+			streamLoop: for try await event in stream {
+				switch event.type {
+				case .action:
+					if let s = event.data.speak ?? event.data.content, !s.isEmpty { onActionText?(s) }
+				case .continue:
+					if let c = event.data.content, !c.isEmpty { onStreamChunk?(c) }
+				case .complete:
+					break streamLoop
+				}
+			}
+		} catch {
+			if canRetry, isRecoverable(error) {
+				callComplete = false
+				onActionText?("세션 초기화 후 재시도…")
+				await resetAgentState()
+				try? await Task.sleep(nanoseconds: 300_000_000)
+				await _startStreaming(content: content, canRetry: false)
+				return
+			}
+			onError?(error.localizedDescription)
+		}
+	}
+	
+	
+	private func isRecoverable(_ error: Error) -> Bool {
+		if let e = error as? AlanSSEClientError {
+			switch e {
+			case .badHTTPStatus(let code):
+				return code == 500
+			case .badContentType:
+				return true
+			}
+		}
+		return false
+	}
+	
+	private func resetAgentState() async {
+		let ep = APIEndpoint.resetState(clientID: clientID)
+		do { _ = try await networkService.request(endpoint: ep, as: AlanResetStateResponse.self) }
+		catch { onError?("세션 초기화 실패: \(error.localizedDescription)") }
+	}
+	
+	
+	// MARK: - DEBUG Mock Streaming
+	private func startMockStreaming(_ content: String) {
+		streamTask = Task { [weak self] in
+			guard let self else { return }
+			defer { self.onStreamCompleted?() }
+			
+			struct Mock: Decodable {
+				struct Action: Decodable { let name: String; let speak: String }
+				let action: Action
+				let content: String
+			}
+			
+			do {
+				guard let url = Bundle.main.url(forResource: "mock_ask_response", withExtension: "json") else {
+					self.onActionText?("모킹 파일을 찾을 수 없어요.")
+					return
+				}
+				let data = try Data(contentsOf: url)
+				let mock = try JSONDecoder().decode(Mock.self, from: data)
+				
+				if !mock.action.speak.isEmpty {
+					self.onActionText?(mock.action.speak)
+				}
+				
+				for ch in mock.content {
+					try await Task.sleep(nanoseconds: 30_000_000) // 30ms
+					self.onStreamChunk?(String(ch))
+				}
+			} catch {
+				self.onError?(error.localizedDescription)
+			}
+		}
+	}
+}
+
+/*
+ func startStreamingQuestion(_ content: String) {
+#if DEBUG
+	 // ── Debug: 로컬 목 JSON을 “한 글자씩” 흘려서 SSE처럼 보이게
+	 Task { @MainActor [weak self] in
+		 guard let self else { return }
+		 defer { self.onStreamCompleted?() }
+		 
+		 struct Mock: Decodable {
+			 struct Action: Decodable { let name: String; let speak: String }
+			 let action: Action
+			 let content: String
+		 }
+		 
+		 do {
+			 guard let url = Bundle.main.url(forResource: "mock_ask_response", withExtension: "json") else {
+				 self.onActionText?("모킹 파일을 찾을 수 없어요.")
+				 return
+			 }
+			 let data = try Data(contentsOf: url)
+			 let mock = try JSONDecoder().decode(Mock.self, from: data)
+			 
+			 if mock.action.speak.isEmpty == false {
+				 self.onActionText?(mock.action.speak)
+			 }
+			 
+			 // 실제 SSE 느낌: 20~40ms 간격으로 한 글자씩
+			 for ch in mock.content {
+				 try await Task.sleep(nanoseconds: 30_000_000)
+				 self.onStreamChunk?(String(ch))
+			 }
+		 } catch {
+			 self.errorMessage = error.localizedDescription
+		 }
+	 }
+	 #else
+	 // ── Release: 실제 SSE
+	 do {
+		 let safe = PrivacyService.maskSensitiveInfo(in: content)
+		 let url = try buildStreamingURL(content: safe, clientID: clientID)
+		 let client = AlanSSEClient()
+		 self.sseClient = client
+		 
+		 let stream = client.connect(url: url)
+		 Task { @MainActor [weak self]  in
+			 guard let self else { return }
+			 defer {
+				 self.sseClient?.disconnect()
+				 self.sseClient = nil
+				 self.onStreamCompleted?()
+			 }
+			 
+			 do {
+				 streamLoop: for try await event in stream {
+					 switch event.type {
+					 case .action:
+						 if let speak = event.data.speak ?? event.data.content, !speak.isEmpty {
+							 self.onActionText?(speak)
+						 }
+					 case .continue:
+						 if let piece = event.data.content, !piece.isEmpty {
+							 self.onStreamChunk?(piece)
+						 }
+					 case .complete:
+						 break streamLoop
+					 }
+				 }
+			 } catch {
+				 self.errorMessage = error.localizedDescription
+			 }
+		 }
+	 } catch {
+		 self.errorMessage = error.localizedDescription
+		 self.onStreamCompleted?()
+	 }
+	 #endif
+ }
+ 
+ 
+ 
+ */


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close #121 응답값 끝에 잘리는 이슈 해결 
https://github.com/rlarjsdn3/EST-Soft-Team3-3rd-Project/pull/121#pullrequestreview-3126595303

---

## ✅ 변경사항
### 1. 응답값 잘림 현상 해결
-  문제
   - AIResponseCell에서 여러 줄 텍스트를 표시할 때 마지막 줄이 잘리거나 셀 높이가 맞지 않는 문제가 발생함.
   - 특히 회전, 다이내믹 타입, 스트리밍 입력(typewriter effect) 상황에서 재현됨.

-  원인
   -  UITableView의 automatic dimension이 UITextView의 최신 contentSize를 반영하지 못하는 경우가 있었음
   -  UITextView 기본 동작(`allowsNonContiguousLayout = true`)으로 인해 줄바꿈 시 부분 레이아웃만 업데이트되어 잘림 발생
   -  텍스트 변경 직후 셀 전체(contentView) 레이아웃이 확정되지 않은 상태에서 높이 계산이 이루어짐
-  해결
   -  responseTextView에 allowsNonContiguousLayout = false 설정 → 줄바꿈 시 레이아웃 안정화
   -  systemLayoutSizeFitting 오버라이드 → sizeThatFits 기반으로 정확한 높이 반환, 항상 올바른 셀 높이 반영
   -  텍스트 갱신 시 contentView.layoutIfNeeded()를 호출한 뒤 onContentGrew 실행 → 테이블뷰 높이 계산과 레이아웃 사이클 동기화
### 2. 챗봇 관련 코드 서비스, Parser, Client 레이어 생성
Chatbot 관련 구조 
```bash
├── ViewModels
│       └── AlanViewModel.swift        // UI 이벤트만 처리
│       └── ChatbotViewModel.swift
├── Services
│   └── SSE
│       ├── AlanSSEClient.swift         // SSE 네트워크 처리
│       ├── AlanSSEParser.swift         // json parsing, 문자 처리
│       └── AlanSSEService.swift       // SSE 로직, ViewModel과 분리
├── Presentation
│   └── Chatbot
│       ├── ChatbotViewController.swift
│       └── Views/
├── Model
│   └── Alan
│       └── AlanStreamingResponse.swift
```
### 3. DIContainer+register - Service등록, DIContainer+Keys에 type형으로 ChatbotViewModel 추가 
- 호출 순서 변경 및 호출  배치 이유 주석 추가
```Swift
       /// 인프라/독립 서비스 먼저 (Network, Privacy, SSE Client/Service 등)
	/// 스토리지/플랫폼 (CoreData/HealthKit 등)
	/// 그 위에 의존하는 도메인 서비스
	/// ViewModel은 최후 (서비스 다 준비된 뒤)
	///
    /// ## 등록되는 서비스 및 ViewModel (등록 순서):
    /// 1. `NetworkService` - 네트워크 통신 서비스 (독립적)
    /// 2. `HealthService` - HealthKit 데이터 조회 서비스 (독립적)
    /// 3. `DailyStepViewModel` - 일일 걸음 수 관리 (Core Data 의존)
	/// 4. `PrivacyService` - 기본 개인정보 서비스 마스킹 처리(독립적)
    /// 5. `GoalStepCountViewModel` - 목표 걸음 수 관리 (Core Data 의존)
    /// 6. `StepSyncViewModel` - 걸음 수 동기화 (위 모든 서비스에 의존)

    func registerAllServices() {
		// 인프라 계층(독립적) - network, privacy, sse client/service 등
        registerNetworkService()
		registerPrivacyService()
		registerAlanSSELayerService()
		// 플랫폼/스토리지 - CoreData, HealthKit
        registerHealthService()
        registerCoreDataUserService()
		// 도메인/기능 서비스 - 상단에 있는 서비스에 의존하는 도메인 서비스
        registerPromptRenderService()
        registerPromptBuilderService()
        registerStepSyncService()
        registerCalendarStepService()
		// ViewModels - 서비스가 다 준비된 뒤 마지막에 로드
		registerDailyStepViewModel()
		registerGoalStepCountViewModel()
		registerUserInfoViewModel()
		registerChatbotViewModel()
    }
```

### 4. AlanViewModel, ChatbotViewModel 분리 - AlanViewModel(일반 요청 응답값), ChatbotViewModel(SSE 응답값 : 챗봇 전용 프롬프트 설계 코드 추가)
---
## 참고사항

-  (DIContainer+Register, DIContainer+Key 쪽 추가했으니 이상있으니, 컨벤션에 어긋나는건 없는지도 봐주심 감사하겠습니다.
- AlanViewModel, ChatbotViewModel 분리 했으니 AlanViewModel에서 영향을 받는게 있는지 없는지 재확인 부탁드려요. SSE 안쓰신다 해서 그 코드만 빼긴 했습니다.
-  디버그 모드, 릴리즈 모드에서 채팅 치고 이상 있는지 없는지만 비교 부탁드려요. 네트워크는 응답값 다 받고 나서, 와이파이, 셀룰러 끄면 메시지 유실 뜨고, 켜면 네트웤 복구 메시지 뜨면 정상적인 겁니다. 
--
## 🌈 이미지

| 응답값 잘리는 현상  | 마지막 응답값까지 나오는 모습  |
| :-:| :-: |
| <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 01 29 34" src="https://github.com/user-attachments/assets/22825bd5-ec78-445c-8975-fbbb93b7b666" />  |  <img width="300" alt="aiResponse_해결" src="https://github.com/user-attachments/assets/e03de34c-1294-42b4-a3a5-3d33e03bf225" />  |


| 연결 복구  | 연결 유실 메시지  |
| :-:| :-: |
|<img width="300"  alt="IMG_5018" src="https://github.com/user-attachments/assets/f4ff15e0-49c7-46aa-9c08-0a87fa269da7" /> | <img width="300" alt="IMG_5017" src="https://github.com/user-attachments/assets/cbbc8ede-549c-4915-b01e-a837031fb93a" /> |








---

### 💜 결과

-
