### PR TITLE
feat: 캘린더 탭에 현재 월로 스크롤되는 버튼 추가

### DIFF
--- a/Health/Presentation/Calendar/Calendar.storyboard
+++ b/Health/Presentation/Calendar/Calendar.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -27,6 +28,24 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WDr-t8-Ze0">
+                                <rect key="frame" x="322" y="703" width="56" height="56"/>
+                                <color key="backgroundColor" name="AccentColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="56" id="KbM-6h-5cL"/>
+                                    <constraint firstAttribute="width" constant="56" id="MTY-la-jEd"/>
+                                </constraints>
+                                <color key="tintColor" systemColor="labelColor"/>
+                                <buttonConfiguration key="configuration" style="plain" image="arrow.uturn.backward" catalog="system"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <integer key="value" value="28"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="scrollToCurrentButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="VHD-kh-qC4"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Xqh-mz-GXE"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -34,11 +53,14 @@
                             <constraint firstAttribute="bottom" secondItem="2Le-zB-m9C" secondAttribute="bottom" id="2Ql-6p-eNk"/>
                             <constraint firstItem="2Le-zB-m9C" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="826-EY-kME"/>
                             <constraint firstAttribute="trailing" secondItem="2Le-zB-m9C" secondAttribute="trailing" id="98L-ox-m3H"/>
+                            <constraint firstAttribute="trailing" secondItem="WDr-t8-Ze0" secondAttribute="trailing" constant="15" id="B3P-NG-VoK"/>
+                            <constraint firstItem="Xqh-mz-GXE" firstAttribute="bottom" secondItem="WDr-t8-Ze0" secondAttribute="bottom" constant="25" id="yat-72-O82"/>
                             <constraint firstItem="2Le-zB-m9C" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="yyB-sf-Q8c"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="2Le-zB-m9C" id="vF1-VD-bDP"/>
+                        <outlet property="scrollToCurrentButton" destination="WDr-t8-Ze0" id="rji-6y-daa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -47,6 +69,13 @@
         </scene>
     </scenes>
     <resources>
+        <image name="arrow.uturn.backward" catalog="system" width="128" height="113"/>
+        <namedColor name="AccentColor">
+            <color red="1" green="0.79199999570846558" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
@@ -48,6 +48,16 @@ final class CalendarScrollManager {
         }
     }
 
+    /// 현재 월로 스크롤합니다.
+    func scrollToCurrentMonth(animated: Bool = false) {
+        guard let collectionView = collectionView,
+              let calendarVM,
+              let indexPath = calendarVM.indexOfCurrentMonth() else {
+            return
+        }
+        collectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
+    }
+
     /// 화면 회전 시 스크롤 위치를 처리합니다.
     func handleDeviceRotation(coordinator: UIViewControllerTransitionCoordinator) {
         // 회전 전 현재 화면 최상단에 보이는 월을 기억
@@ -116,16 +126,6 @@ private extension CalendarScrollManager {
         func distanceFromScreenTop(_ screenArea: CGRect) -> CGFloat {
             return abs(frame.minY - screenArea.minY)
         }
-    }
-
-    /// 현재 월로 스크롤합니다.
-    func scrollToCurrentMonth() {
-        guard let collectionView = collectionView,
-              let calendarVM,
-              let indexPath = calendarVM.indexOfCurrentMonth() else {
-            return
-        }
-        collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
     }
 
     /// 현재 화면에서 가장 위에 보이는 월의 IndexPath를 찾습니다.


### PR DESCRIPTION
## 작업내용
- 캘린더 탭 우측 하단에 현재 월로 스크롤할 수 있는 버튼 추가
- 현재 월이 완전히 안보일 때만 노출

## 링크
- [노션 태스크](https://www.notion.so/oreumi/253ebaa8982b8077b48cdd0b02f48fb7?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)