### PR TITLE
feat: 캘린더 탭 달력의 날짜를 누르면 투명도와 크기 조정

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -17,6 +17,8 @@ final class CalendarDateCell: CoreCollectionViewCell {
     private var isBlankCell = false
     private var isCompletedCell = false
 
+    private(set) var isClickable = false
+
     override func setupHierarchy() {
         super.setupHierarchy()
 
@@ -53,6 +55,31 @@ final class CalendarDateCell: CoreCollectionViewCell {
         }
 
         configureCircleViewUI()
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            guard isClickable else { return }
+
+            let alpha: CGFloat = isHighlighted ? 0.75 : 1.0
+            let scale: CGFloat = isHighlighted ? 0.95 : 1.0
+
+            UIView.animate(
+                withDuration: 0.25,
+                delay: 0,
+                options: [.allowUserInteraction, .curveEaseInOut]
+            ) {
+                self.contentView.alpha = alpha
+                self.contentView.transform = CGAffineTransform(scaleX: scale, y: scale)
+            }
+        }
+    }
+
+    // 셀 재사용시 원래 상태 복원 보장
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentView.alpha = 1.0
+        contentView.transform = .identity
     }
 
     private func updateCircleViewConstraints(inset: CGFloat) {
@@ -99,11 +126,13 @@ final class CalendarDateCell: CoreCollectionViewCell {
         // 빈 셀 처리
         if date == .distantPast {
             isBlankCell = true
+            isClickable = false
             configureForBlank()
             return
         }
 
         isBlankCell = false
+        isClickable = date.startOfDay() <= Date().startOfDay()
         dateLabel.text = "\(date.day)"
 
         // 데이터 없음 처리

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -52,6 +52,7 @@ final class CalendarMonthCell: CoreCollectionViewCell {
 }
 
 extension CalendarMonthCell: UICollectionViewDataSource {
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         datesWithBlank.count
     }
@@ -72,6 +73,15 @@ extension CalendarMonthCell: UICollectionViewDataSource {
 }
 
 extension CalendarMonthCell: UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? CalendarDateCell else {
+            return false
+        }
+        let date = datesWithBlank[indexPath.item]
+        return date != .distantPast && cell.isClickable
+    }
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let date = datesWithBlank[indexPath.item]
         guard date != .distantPast, date <= Date() else { return }


### PR DESCRIPTION
## 작업내용
- 캘린더 탭 달력에 날짜를 눌렀을 때 셀의 투명도와 크기를 변경
(투명도는 75%, 크기는 95%)
- 미래 날짜는 눌러도 대시보드가 열리지 않기 때문에 적용 X

## 링크
- [노션 태스크](https://www.notion.so/oreumi/254ebaa8982b803ebc91c91d4e0bdfef?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)