### PR TITLE
design: toastable warning - 경고 토스트 메시지 컬러에셋 추가

### DIFF
--- a/Health/Resources/Assets.xcassets/Toastable-warning/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Health/Resources/Assets.xcassets/Toastable-warning/toastStrokeColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/toastStrokeColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE7",
+          "green" : "0xE7",
+          "red" : "0xE7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xAF",
+          "red" : "0xAF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Health/Resources/Assets.xcassets/Toastable-warning/toastSubTitleColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/toastSubTitleColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6A",
+          "green" : "0x6A",
+          "red" : "0x6A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCB",
+          "green" : "0xCB",
+          "red" : "0xCB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Health/Resources/Assets.xcassets/Toastable-warning/toastSubTitleColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/toastSubTitleColor.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xCB",
-          "green" : "0xCB",
-          "red" : "0xCB"
+          "blue" : "0xD7",
+          "green" : "0xD7",
+          "red" : "0xD7"
         }
       },
       "idiom" : "universal"

--- a/Health/Resources/Assets.xcassets/Toastable-warning/toastWarningBgColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/toastWarningBgColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5B",
+          "green" : "0xD3",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x47",
+          "green" : "0x9D",
+          "red" : "0xA7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Health/Resources/Assets.xcassets/Toastable-warning/warningSymbolColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/Toastable-warning/warningSymbolColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x8E",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0xF5",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

-  토스트 메시지 배경색
- 토스트 메시지 스트로크
- 토스트 메시지 심볼색
- 토스트 메시지 subtitle 색(dark `#d7d7d7`로 변경)
- 토스트메시지 title 색은 `.label`(white, black) 그냥 쓰심 됩니다.
- alpha값은 1.0 으로 맞춰주시면 됩니다.

### 💜 결과
<img width="300"  alt="CleanShot 2025-08-19 at 22 12 38@2x" src="https://github.com/user-attachments/assets/749942d6-7da9-42fc-abd4-6bfd9a68de4c" />
<img width="300"  alt="CleanShot 2025-08-19 at 22 14 20@2x" src="https://github.com/user-attachments/assets/664fbf70-0c49-4811-b525-b20295e29642" />

-
