### PR TITLE
fix: 고장난 GitHub Action 수리, Xcode 버전을 `16.1`에서 `16.4`로 업데이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Set Specific Xcode Version
-          run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
         - name: Generate app-debug xcconfig
           run: echo "${{ secrets.DEBUG_XCCONFIG }}" > ./app-debug.xcconfig
@@ -29,5 +29,5 @@ jobs:
             xcodebuild clean test \
             -project Health.xcodeproj \
             -scheme Health-DEBUG \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.1' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4' \
             -xcconfig ./app-debug.xcconfig


### PR DESCRIPTION
- 고장난 GitHub Action을 고쳤어요.

> 깃허브 액션 상에서는 Xcode 16.4 버전과 iOS 18.4를 기준으로 빌드 및 테스트를 수행합니다. 가급적 Xcode 16.4 버전 이상으로 업데이트해주실 것을 권장드립니다~
