### PR TITLE
fix: 캘린더 탭에서 무한스크롤이 제대로 동작하지 않는 문제 수정

### DIFF
--- a/Health/Core/ViewControllers/HealthTabBarController.swift
+++ b/Health/Core/ViewControllers/HealthTabBarController.swift
@@ -13,6 +13,7 @@ final class HealthTabBarController: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.delegate = self
         configureTabBarAppearance()
     }
 
@@ -39,5 +40,15 @@ final class HealthTabBarController: UITabBarController {
 
         self.tabBar.frame.size.height = tabHeight
         self.tabBar.frame.origin.y = view.frame.height - tabHeight
+    }
+}
+
+extension HealthTabBarController: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if let nav = viewController as? UINavigationController,
+           let calendarVC = nav.viewControllers.first as? CalendarViewController {
+            /// 캘린더 탭이 선택된 경우 현재 월로 스크롤하도록 설정
+            calendarVC.shouldScrollToCurrentOnAppear = true
+        }
     }
 }

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -4,7 +4,15 @@ final class CalendarViewController: CoreGradientViewController {
 
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var scrollToCurrentButton: UIButton!
-    
+
+    /// 뷰가 나타날 때 현재 월로 스크롤할지 여부를 결정하는 플래그
+    ///
+    /// 탭 전환 시(`true`)와 화면 내 네비게이션(`false`) 시나리오를 구분하여 적절한 스크롤 동작을 제어합니다.
+    /// `viewWillAppear(_:)`에서 사용된 후 자동으로 `false`로 리셋되어 일회성 동작을 보장합니다.
+    ///
+    /// - Note: 다른 탭에서 달력 탭으로 전환할 때만 `true`로 설정하고, 달력 내 push/pop 시에는 기본값(`false`)을 유지합니다.
+    var shouldScrollToCurrentOnAppear = false
+
     private let calendarVM = CalendarViewModel()
     private lazy var scrollManager = CalendarScrollManager(calendarVM: calendarVM, collectionView: collectionView)
 
@@ -19,30 +27,35 @@ final class CalendarViewController: CoreGradientViewController {
             name: .stepDataDidSync,
             object: nil
         )
+        observeDataChanges()
     }
 
     override func setupAttribute() {
         super.setupAttribute()
 		configureBackground()
         configureCollectionView()
-        observeDataChanges()
+        hideScrollToCurrentButtonImmediately()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        scrollManager.handleViewWillAppear()
+
+        scrollManager.handleViewWillAppear(shouldScrollToCurrentOnAppear)
+
+        if shouldScrollToCurrentOnAppear {
+            hideScrollToCurrentButtonImmediately()
+        }
+
+        shouldScrollToCurrentOnAppear = false // 기본값으로 복원
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         scrollManager.handleViewDidLayoutSubviews()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        // 메모리 해제를 위한 Task 취소
-        dataChangesTask?.cancel()
-        dataChangesTask = nil
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -55,6 +68,11 @@ final class CalendarViewController: CoreGradientViewController {
         // scrollManager.handleDeviceRotation()을 호출하도록 제한.
         guard viewIfLoaded?.window != nil else { return }
         scrollManager.handleDeviceRotation(coordinator: coordinator)
+    }
+
+    deinit {
+        dataChangesTask?.cancel()
+        dataChangesTask = nil
     }
 
     @IBAction func scrollToCurrentButtonTapped(_ sender: Any) {
@@ -167,13 +185,6 @@ private extension CalendarViewController {
     }
 
     func updateScrollToCurrentButtonVisibility() {
-        // 초기 스크롤이 끝나기 전에는 버튼을 숨긴 상태 유지
-        guard scrollManager.didFinishInitialScroll else {
-            scrollToCurrentButton.alpha = 0
-            scrollToCurrentButton.isHidden = true
-            return
-        }
-
         guard let currentIndexPath = calendarVM.indexOfCurrentMonth() else { return }
 
         let visibleIndexPaths = collectionView.indexPathsForVisibleItems
@@ -200,6 +211,13 @@ private extension CalendarViewController {
                 self?.scrollToCurrentButton.isHidden = true
             }
         }
+	}
+
+    func hideScrollToCurrentButtonImmediately() {
+        guard !scrollToCurrentButton.isHidden else { return }
+
+        scrollToCurrentButton.alpha = 0
+        scrollToCurrentButton.isHidden = true
     }
 
     @objc func reloadCalendar() {
@@ -234,7 +252,11 @@ extension CalendarViewController: UICollectionViewDelegate {
     /// 스크롤 시 무한 스크롤 처리 및 현재 월로 스크롤하는 버튼 표시 여부 업데이트
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         scrollManager.handleScrollForInfiniteLoading(scrollView)
-        updateScrollToCurrentButtonVisibility()
+
+        // 현재 월로 스크롤이 최초 1회 되고 나서부터 실행
+        if scrollManager.isInitialScrollSettled {
+            updateScrollToCurrentButtonVisibility()
+        }
     }
 
     /// 상단바를 탭해서 최상단으로 스크롤하는 동작 방지

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -49,10 +49,6 @@ final class CalendarViewController: CoreGradientViewController {
         shouldScrollToCurrentOnAppear = false // 기본값으로 복원
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
-
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         scrollManager.handleViewDidLayoutSubviews()


### PR DESCRIPTION
## 작업내용
- 3가지 문제점을 수정했습니다.
    1. 캘린더 탭이 disappear 되고나서 다시 돌아왔을 때 무한스크롤이 동작하지 않는 문제
    2. 달력의 날짜를 탭해서 열리는 대시보드창을 닫았을 때 현재 월로 스크롤이 초기화되는 문제
    3. 현재 월로 스크롤시키는 버튼이 간혹 현재 월이 화면에 보이더라도 숨겨지지 않는 문제

## 링크
- [노션 태스크](https://www.notion.so/oreumi/254ebaa8982b8032ab1be9c37c49337e?source=copy_link)