### PR TITLE
refactor: detailLabel 셀의 우측으로 수정, 컬러변경

### DIFF
--- a/Health/Presentation/Profile/BodyInfoViewController.swift
+++ b/Health/Presentation/Profile/BodyInfoViewController.swift
@@ -131,12 +131,16 @@ extension BodyInfoViewController: UITableViewDataSource {
         var content = cell.defaultContentConfiguration()
         content.image = UIImage(systemName: item.iconName)
         content.text = item.title
+        content.textProperties.color = .systemGray
         content.imageProperties.tintColor = .systemGray
-        content.secondaryText = item.detail
-        content.secondaryTextProperties.color = .systemGray
-        
         cell.contentConfiguration = content
-        cell.accessoryType = .none
+        
+        let detailLabel = UILabel()
+        detailLabel.text = item.detail
+        detailLabel.textColor = .label
+        detailLabel.sizeToFit()
+        
+        cell.accessoryView = detailLabel
         cell.selectionStyle = .none
         cell.backgroundColor = UIColor.buttonText.withAlphaComponent(0.1)
         


### PR DESCRIPTION


## ✅ 변경사항

- 신체 정보에서 Title 아래에 있던 DetailText를 우측으로 옮겼습니다.

---


## 🌈 이미지

-
<img width="324" height="272" alt="image" src="https://github.com/user-attachments/assets/03645e25-4f49-40b5-b985-7a40970b19a9" />


### 💜 결과

-
