### PR TITLE
feat: 캘린더 탭 달력의 날짜 중 유효한 걸음 수 데이터가 있는 셀만 클릭이 가능하도록 수정

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -60,14 +60,8 @@ extension CalendarMonthCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarDateCell.id, for: indexPath) as! CalendarDateCell
         let date = datesWithBlank[indexPath.item]
-
-        if date == .distantPast || date > Date() {
-            cell.configure(date: date, currentSteps: nil, goalSteps: nil)
-        } else {
-            let (current, goal) = stepService.steps(for: date)
-            cell.configure(date: date, currentSteps: current, goalSteps: goal)
-        }
-
+        let (current, goal) = stepService.steps(for: date)
+        cell.configure(date: date, currentSteps: current, goalSteps: goal)
         return cell
     }
 }
@@ -75,16 +69,12 @@ extension CalendarMonthCell: UICollectionViewDataSource {
 extension CalendarMonthCell: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? CalendarDateCell else {
-            return false
-        }
-        let date = datesWithBlank[indexPath.item]
-        return date != .distantPast && cell.isClickable
+        let cell = collectionView.cellForItem(at: indexPath) as! CalendarDateCell
+        return cell.isSelectable
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let date = datesWithBlank[indexPath.item]
-        guard date != .distantPast, date <= Date() else { return }
         onDateSelected?(date)
     }
 }


### PR DESCRIPTION
## 작업내용
- 달력에서 현재 걸음 수와 목표 걸음 수 데이터가 있는 날짜만 클릭이 가능하도록 수정했습니다.
- CalendarDateCell.swift의 private method들은 `extension`으로 분리했습니다.

## 링크
- [노션 태스크](https://www.notion.so/oreumi/254ebaa8982b80b59f5dd25071dd996b?source=copy_link)