### PR TITLE
feat: `DashboardTopBarViewModel` 코드작성 및 Pull-to-Referesh 시, 기준 시각이 제대로 갱신되지 않는 문제 수정

### DIFF
--- a/Health/Presentation/Dashboard/Content/DashboardContent.swift
+++ b/Health/Presentation/Dashboard/Content/DashboardContent.swift
@@ -26,7 +26,7 @@ enum DashboardContent {
 
     enum Item: Hashable, Sendable {
         /// 상단 바 항목
-        case topBar
+        case topBar(DashboardTopBarViewModel.ItemID)
         /// 목표 링 셀
         case goalRing(DailyGoalRingCellViewModel.ItemID)
         /// 건강 정보 스택 셀
@@ -47,7 +47,7 @@ extension DashboardContent.Item {
 
     func dequeueReusableCollectionViewCell(
         collectionView: UICollectionView,
-        topBarCellRegistration: UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, Void>,
+        topBarCellRegistration: UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, DashboardTopBarViewModel.ItemID>,
         dailyGoalRingCellRegistration: UICollectionView.CellRegistration<DailyGoalRingCollectionViewCell, DailyGoalRingCellViewModel.ItemID>,
         healthInfoStackCellRegistration: UICollectionView.CellRegistration<HealthInfoStackCollectionViewCell, HealthInfoStackCellViewModel.ItemID>,
         barChartsCellRegistration: UICollectionView.CellRegistration<DashboardBarChartsCollectionViewCell, DashboardBarChartsCellViewModel.ItemID>,
@@ -57,11 +57,11 @@ extension DashboardContent.Item {
         indexPath: IndexPath
     ) -> UICollectionViewCell {
         switch self {
-        case .topBar:
+        case let .topBar(id):
             return collectionView.dequeueConfiguredReusableCell(
                 using: topBarCellRegistration,
                 for: indexPath,
-                item: ()
+                item: id
             )
         case let .goalRing(id):
             return collectionView.dequeueConfiguredReusableCell(

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -82,12 +82,8 @@ final class DashboardViewController: CoreGradientViewController {
     }
 
     @objc private func refreshHKData() {
-        // TODO: - 리프레시 시, AI 요약도 함께 리프레시되도록 하기
         viewModel.loadHKData(includeAISummary: true)
-
-        Task.delay(for: 1.0) { @MainActor in
-            refreshControl.endRefreshing()
-        }
+        Task.delay(for: 1.0) { @MainActor in refreshControl.endRefreshing() }
     }
 
 
@@ -158,7 +154,12 @@ fileprivate extension DashboardViewController {
 
     private func appendTopBarSection(to snapshot: inout NSDiffableDataSourceSnapshot<DashboardContent.Section, DashboardContent.Item>) {
         snapshot.appendSections([.top])
-        snapshot.appendItems([.topBar], toSection: .top)
+
+        var items: [DashboardContent.Item] = []
+        viewModel.topIDs.forEach { id in
+            items.append(.topBar(id))
+        }
+        snapshot.appendItems(items, toSection: .top)
     }
 
     private func appendGoalRingSection(to snapshot: inout NSDiffableDataSourceSnapshot<DashboardContent.Section, DashboardContent.Item>) {
@@ -218,9 +219,10 @@ fileprivate extension DashboardViewController {
 
 fileprivate extension DashboardViewController {
 
-    func createTopBarCellRegistration() -> UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, Void> {
-        UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, Void>(cellNib: DashboardTopBarCollectionViewCell.nib) { [weak self] cell, indexPath, _ in
-            cell.update(with: self?.viewModel.anchorDate ?? .now)
+    func createTopBarCellRegistration() -> UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, DashboardTopBarViewModel.ItemID> {
+        UICollectionView.CellRegistration<DashboardTopBarCollectionViewCell, DashboardTopBarViewModel.ItemID>(cellNib: DashboardTopBarCollectionViewCell.nib) { [weak self] cell, indexPath, id in
+            guard let vm = self?.viewModel.topCells[id] else { return }
+            cell.bind(with: vm)
         }
     }
 

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -34,7 +34,7 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
         }
         newAttrs.size.height = contentHeight
         return newAttrs
-
+        // TODO: - 제약만으로 셀의 셀프-사이징이 동작하도록 코드 개선하기
     }
 
     override func setupAttribute() {

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardTopBarCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardTopBarCollectionViewCell.swift
@@ -5,6 +5,7 @@
 //  Created by 김건우 on 8/1/25.
 //
 
+import Combine
 import UIKit
 
 final class DashboardTopBarCollectionViewCell: CoreCollectionViewCell {
@@ -12,6 +13,15 @@ final class DashboardTopBarCollectionViewCell: CoreCollectionViewCell {
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var weekDayLabel: UILabel!
     @IBOutlet weak var anchorDateLabel: UILabel!
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    private var viewModel: DashboardTopBarViewModel!
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cancellables.removeAll()
+    }
 
     override func setupAttribute() {
         super.setupAttribute()
@@ -24,7 +34,17 @@ final class DashboardTopBarCollectionViewCell: CoreCollectionViewCell {
 
 extension DashboardTopBarCollectionViewCell {
 
-    func update(with date: Date) {
+    func bind(with viewModel: DashboardTopBarViewModel) {
+        self.viewModel = viewModel
+
+        viewModel.statePublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] date in self?.update(with: date) }
+            .store(in: &cancellables)
+    }
+
+    private func update(with date: Date) {
         dateLabel.text = date.formatted(using: .md)
         weekDayLabel.text = date.formatted(using: .weekday)
         anchorDateLabel.text = "(\(date.formatted(using: .h_m)) 기준)"

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardTopBarCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardTopBarCollectionViewCell.swift
@@ -19,16 +19,7 @@ final class DashboardTopBarCollectionViewCell: CoreCollectionViewCell {
     private var viewModel: DashboardTopBarViewModel!
 
     override func prepareForReuse() {
-        super.prepareForReuse()
         cancellables.removeAll()
-    }
-
-    override func setupAttribute() {
-        super.setupAttribute()
-
-        dateLabel.text = Date.now.formatted(using: .md)
-        weekDayLabel.text = Date.now.formatted(using: .weekday)
-        anchorDateLabel.text = "(\(Date.now.formatted(using: .h_m)) 기준)"
     }
 }
 

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -24,7 +24,14 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
     private var borderWidth: CGFloat {
         (traitCollection.userInterfaceStyle == .dark) ? 0 : 0.75
     }
-    
+
+    private var defaultFormatter: NumberFormatter = {
+        let nf = NumberFormatter()
+        nf.minimumFractionDigits = 1
+        nf.maximumFractionDigits = 1
+        return nf
+    }()
+
     private var percentageFormatter: NumberFormatter = {
         let nf = NumberFormatter()
         nf.numberStyle = .percent
@@ -97,10 +104,12 @@ extension HealthInfoCardCollectionViewCell {
             statusProgressBarView.currentValue = content.value
             statusProgressBarView.numberFormatter = {
                 switch viewModel.itemID.kind {
-                case .walkingSpeed, .walkingStepLength:
-                    return nil
+                case .walkingSpeed:
+                    return defaultFormatter
                 case .walkingAsymmetryPercentage, .walkingDoubleSupportPercentage:
                     return percentageFormatter
+                default:
+                    return nil
                 }
             }()
             

--- a/Health/ViewModels/Cells/DashboardBarChartsCellViewModel.swift
+++ b/Health/ViewModels/Cells/DashboardBarChartsCellViewModel.swift
@@ -11,7 +11,7 @@ import HealthKit
 typealias DashboardChartsContent = DashboardBarChartsCellViewModel.Content
 typealias DashboardChartsContents = [DashboardChartsContent]
 
-final class DashboardBarChartsCellViewModel { // TODO: - Cell에서 처리하고 있는 HKData 페치 로직을 VC의 VM으로 빼보기
+final class DashboardBarChartsCellViewModel {
     
     ///
     struct ItemID: Hashable {

--- a/Health/ViewModels/Cells/DashboardTopBarViewModel.swift
+++ b/Health/ViewModels/Cells/DashboardTopBarViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  DashboardTopBarViewModel.swift
+//  Health
+//
+//  Created by 김건우 on 8/20/25.
+//
+
+import Combine
+import HealthKit
+
+final class DashboardTopBarViewModel {
+    ///
+    struct ItemID: Hashable {
+        let id: UUID = UUID()
+    }
+
+    ///
+    private(set) var itemID: ItemID
+
+    ///
+    private let stateSubject = CurrentValueSubject<Date, Never>(.now)
+
+    ///
+    var statePublisher: AnyPublisher<Date, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    ///
+    init(itemID: ItemID) {
+        self.itemID = itemID
+    }
+
+    ///
+    func renewalAnchorDate(_ new: Date) {
+        stateSubject.send(new)
+    }
+}
+
+
+extension DashboardTopBarViewModel: Hashable {
+
+    nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(itemID)
+    }
+
+    nonisolated static func == (lhs: DashboardTopBarViewModel, rhs: DashboardTopBarViewModel) -> Bool {
+        return lhs.itemID.id == rhs.itemID.id
+    }
+}
+

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -17,6 +17,9 @@ final class DashboardViewModel {
 
     private(set) var anchorDate: Date
 
+    private(set) var topIDs: [DashboardTopBarViewModel.ItemID] = []
+    private(set) var topCells: [DashboardTopBarViewModel.ItemID: DashboardTopBarViewModel] = [:]
+
     private(set) var goalRingIDs: [DailyGoalRingCellViewModel.ItemID] = []
     private(set) var goalRingCells: [DailyGoalRingCellViewModel.ItemID: DailyGoalRingCellViewModel] = [:]
 
@@ -48,6 +51,7 @@ final class DashboardViewModel {
 
     ///
     func buildDashboardCells(for environment: DashboardEnvironment) {
+        buildTopBarCell()
         buildStackCells()
         buildGoalRingCells()
         buildCardCells()
@@ -57,6 +61,18 @@ final class DashboardViewModel {
             buildAlanSummaryCells()
             buildBarChartsCells(for: environment)
         }
+    }
+
+    private func buildTopBarCell() {
+        let newIDs = [DashboardTopBarViewModel.ItemID()]
+
+        var newCells: [DashboardTopBarViewModel.ItemID: DashboardTopBarViewModel] = [:]
+        newIDs.forEach { id in
+            newCells.updateValue(DashboardTopBarViewModel(itemID: id), forKey: id)
+        }
+
+        topIDs = newIDs
+        topCells = newCells
     }
 
     private func buildGoalRingCells() {
@@ -154,11 +170,18 @@ final class DashboardViewModel {
 extension DashboardViewModel {
 
     func loadHKData(includeAISummary: Bool = true) {
+        loadAnchorDateForTopCell()
         loadHKDataForGoalRingCells()
         loadHKDataForStackCells()
         if includeAISummary { loadAlanAIResponseForSummaryCells() }
         loadHKDataForCardCells()
         loadHKDataForBarChartsCells()
+    }
+
+    func loadAnchorDateForTopCell() {
+        for (_, vm) in topCells {
+            vm.renewalAnchorDate(.now)
+        }
     }
 
     func loadHKDataForGoalRingCells() {
@@ -330,8 +353,6 @@ extension DashboardViewModel {
     }
 
     func loadAlanAIResponseForSummaryCells() {
-        // TODO: - 앨런 프롬프트 작성에 필요한 건강 데이터 불러오기
-
         Task {
             for (_, vm) in self.summaryCells {
                 vm.setState(.loading)


### PR DESCRIPTION
[Notion Task](https://www.notion.so/oreumi/Pull-to-Refresh-254ebaa8982b80dfabd9fefb076132b8?source=copy_link)

## ✅ 변경사항

- `DashboardTopBarViewModel` 코드 작성 및 Pull-to-Refresh 시, 기준 시각이 제대로 갱신되지 않는 문제를 수정하였습니다.
- 대시보드 하단의 `보행 밸런스 분석` 셀에서 숫자 포매팅을 더욱 정교하게 처리하도록 코드를 개선하였습니다.

---

## 🌈 이미지

| 1  |
| :-:| 
|   <img width="1179" height="2556" alt="IMG_0489" src="https://github.com/user-attachments/assets/a9b9678a-129d-4287-b5c4-1dd062182b76" /> |    

* 기존에는 `1`, `1.2`, `1.4`...  로 표시되었는데, `1.0`, `1.2`, `1.4`... 로 표시되게 개선하였습니다.
---
