### PR TITLE
feat: 대시보드에 `HealthNavigationBar` 코드 적용 및 캘린더로부터 대시보드에 진입하면 AI 요약을 하지 않도록 코드 수정

### DIFF
--- a/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
+++ b/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
@@ -159,7 +159,7 @@ final class HealthNavigationBar: CoreView {
 
         var config = UIButton.Configuration.plain()
         config.image = chevronLeftImage
-        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 16)
         backButton.configuration = config
         backButton.translatesAutoresizingMaskIntoConstraints = false
         backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)

--- a/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
+++ b/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
@@ -71,8 +71,13 @@ final class HealthNavigationBar: CoreView {
         didSet { self.setNeedsLayout() }
     }
 
+    ///
+    var isTitleLabelHidden: Bool = false {
+        didSet { updateNavigationBarAttributes() }
+    }
+
     // 뒤로가기 버튼의 숨김 여부입니다.
-    var isHiddenBackButton: Bool = false {
+    var isBackButtonHidden: Bool = false {
         didSet { updateNavigationBarAttributes() }
     }
 
@@ -220,7 +225,9 @@ final class HealthNavigationBar: CoreView {
             .applyingSymbolConfiguration(preferredTitleImageSymbolConfiguration ?? defaultSymbolConfiguration)?
             .applyingSymbolConfiguration(defaultSymbolConfiguration)
 
-        backButton.isHidden = isHiddenBackButton
+        titleStackView.isHidden = isTitleLabelHidden
+        centerTitleLabel.isHidden = isTitleLabelHidden
+        backButton.isHidden = isBackButtonHidden
     }
 
     private func configureButtonUpdateHandler(_ button: UIButton) {

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -169,7 +169,7 @@ private extension CalendarViewController {
 
     func navigationToDashboard(with date: Date) {
         let dashboardVC = DashboardViewController.instantiateInitialViewController(name: "Dashboard")
-        dashboardVC.viewModel = DashboardViewModel(anchorDate: date, cameFromCalendar: true)
+        dashboardVC.viewModel = DashboardViewModel(anchorDate: date)
 
         // push 시 탭바가 잠깐 보였다 내려가는 문제로 미리 tabBar를 숨깁니다.
         // pop 해서 DashboardVC가 사라지면 다시 `hidesBottomBarWhenPushed = false`인 화면이 되므로

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -169,7 +169,7 @@ private extension CalendarViewController {
 
     func navigationToDashboard(with date: Date) {
         let dashboardVC = DashboardViewController.instantiateInitialViewController(name: "Dashboard")
-        dashboardVC.viewModel = DashboardViewModel(anchorDate: date)
+        dashboardVC.viewModel = DashboardViewModel(anchorDate: date, cameFromCalendar: true)
 
         // push 시 탭바가 잠깐 보였다 내려가는 문제로 미리 tabBar를 숨깁니다.
         // pop 해서 DashboardVC가 사라지면 다시 `hidesBottomBarWhenPushed = false`인 화면이 되므로

--- a/Health/Presentation/Dashboard/Dashboard.storyboard
+++ b/Health/Presentation/Dashboard/Dashboard.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="q7K-RI-rnj">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <rect key="frame" x="0.0" y="162" width="393" height="690"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="V3N-S7-lxw">
                                     <size key="itemSize" width="128" height="128"/>
@@ -27,18 +27,29 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VrO-zI-wNG" customClass="HealthNavigationBar" customModule="Health" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="118" width="393" height="44"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="9cn-kn-Unf"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="q7K-RI-rnj" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="CGa-xG-vdo"/>
+                            <constraint firstItem="q7K-RI-rnj" firstAttribute="top" secondItem="VrO-zI-wNG" secondAttribute="bottom" id="BC2-bs-dKF"/>
                             <constraint firstItem="q7K-RI-rnj" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="EAL-Gw-Mk4"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="q7K-RI-rnj" secondAttribute="trailing" id="FrC-lK-8WA"/>
+                            <constraint firstItem="VrO-zI-wNG" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="VLZ-78-uHz"/>
+                            <constraint firstItem="VrO-zI-wNG" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="g4V-00-YFu"/>
+                            <constraint firstItem="VrO-zI-wNG" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="guU-jb-IDt"/>
                             <constraint firstAttribute="bottom" secondItem="q7K-RI-rnj" secondAttribute="bottom" id="xKH-7u-HWC"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="dashboardCollectionView" destination="q7K-RI-rnj" id="hDB-Uz-7TY"/>
+                        <outlet property="navigationBar" destination="VrO-zI-wNG" id="KGt-m7-rBz"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -78,13 +78,12 @@ final class DashboardViewController: CoreGradientViewController {
 
         navigationBar.title = "대시보드"
         navigationBar.titleImage = UIImage(systemName: "chart.xyaxis.line")
-        navigationBar.isHidden = viewModel.anchorDate.isEqual(with: .now)
-                                    && !viewModel.cameFromCalendar
+        navigationBar.isTitleLabelHidden = true
     }
 
     @objc private func refreshHKData() {
         // TODO: - 리프레시 시, AI 요약도 함께 리프레시되도록 하기
-        viewModel.loadHKData(includeAISummary: true)
+        viewModel.loadHKData()
 
         Task.delay(for: 1.0) { @MainActor in
             refreshControl.endRefreshing()
@@ -306,9 +305,7 @@ extension DashboardViewController: UICollectionViewDelegate {
         let contentOffset = scrollView.contentOffset
 
         let adjustedOffsetY = contentOffset.y + contentInset.top
-        navigationBar.isHidden = adjustedOffsetY <= 54.0
-                                    && viewModel.anchorDate.isEqual(with: .now)
-                                    && !viewModel.cameFromCalendar
+        navigationBar.isTitleLabelHidden = adjustedOffsetY <= 54.0
     }
 }
 

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -14,8 +14,9 @@ final class DashboardViewController: CoreGradientViewController {
 
     typealias DashboardDiffableDataSource = UICollectionViewDiffableDataSource<DashboardContent.Section, DashboardContent.Item>
 
-    private let refreshControl = UIRefreshControl()
+    @IBOutlet weak var navigationBar: HealthNavigationBar!
     @IBOutlet weak var dashboardCollectionView: UICollectionView!
+    private let refreshControl = UIRefreshControl()
 
     private var dataSource: DashboardDiffableDataSource?
     
@@ -26,11 +27,6 @@ final class DashboardViewController: CoreGradientViewController {
     lazy var viewModel: DashboardViewModel = {
         .init()
     }()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-    }
 
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
@@ -56,6 +52,8 @@ final class DashboardViewController: CoreGradientViewController {
     }
 
     override func setupAttribute() {
+        applyBackgroundGradient(.midnightBlack)
+
         refreshControl.addTarget(
             self,
             action: #selector(refreshHKData),
@@ -69,16 +67,19 @@ final class DashboardViewController: CoreGradientViewController {
             animated: false
         )
         dashboardCollectionView.contentInset = UIEdgeInsets(
-            top: 54, left: .zero, // TODO: - 네비게이션 바에 맞게 인셋 값 조정하기
+            top: 8, left: .zero,
             bottom: 32, right: .zero
         )
         dashboardCollectionView.scrollIndicatorInsets =  UIEdgeInsets(
-            top: 46, left: .zero,
+            top: 16, left: .zero,
             bottom: 24, right: .zero
         )
         dashboardCollectionView.refreshControl = refreshControl
 
-        applyBackgroundGradient(.midnightBlack)
+        navigationBar.title = "대시보드"
+        navigationBar.titleImage = UIImage(systemName: "chart.xyaxis.line")
+        navigationBar.isHidden = viewModel.anchorDate.isEqual(with: .now)
+                                    && !viewModel.cameFromCalendar
     }
 
     @objc private func refreshHKData() {
@@ -300,10 +301,14 @@ fileprivate extension DashboardViewController {
 
 extension DashboardViewController: UICollectionViewDelegate {
 
-    func collectionView(
-        _ collectionView: UICollectionView,
-        didHighlightItemAt indexPath: IndexPath
-    ) {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let contentInset = scrollView.contentInset
+        let contentOffset = scrollView.contentOffset
+
+        let adjustedOffsetY = contentOffset.y + contentInset.top
+        navigationBar.isHidden = adjustedOffsetY <= 54.0
+                                    && viewModel.anchorDate.isEqual(with: .now)
+                                    && !viewModel.cameFromCalendar
     }
 }
 

--- a/Health/Presentation/Dashboard/Views/AISummaryLabel.swift
+++ b/Health/Presentation/Dashboard/Views/AISummaryLabel.swift
@@ -72,7 +72,7 @@ final class AISummaryLabel: CoreView {
         ])
 
         NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 26),
+            imageView.widthAnchor.constraint(equalToConstant: 20),
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 1.0)
         ])
 

--- a/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/AlanActivitySummaryCollectionViewCell.swift
@@ -41,7 +41,7 @@ final class AlanActivitySummaryCollectionViewCell: CoreCollectionViewCell {
         self.backgroundColor = .boxBg
         self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
-        self.layer.borderColor = UIColor.separator.cgColor
+        self.layer.borderColor = UIColor.boxBgLightModeStroke.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)

--- a/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/DashboardBarChartsCollectionViewCell.swift
@@ -36,7 +36,7 @@ final class DashboardBarChartsCollectionViewCell: CoreCollectionViewCell {
         chartsContainerView.applyCornerStyle(.medium)
         chartsContainerView.backgroundColor = .boxBg
         chartsContainerView.layer.masksToBounds = false
-        chartsContainerView.layer.borderColor = UIColor.separator.cgColor
+        chartsContainerView.layer.borderColor = UIColor.boxBgLightModeStroke.cgColor
         chartsContainerView.layer.shadowColor = UIColor.black.cgColor
         chartsContainerView.layer.shadowOpacity = 0.15
         chartsContainerView.layer.shadowOffset = CGSize(width: 2, height: 2)

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -39,7 +39,7 @@ final class HealthInfoCardCollectionViewCell: CoreCollectionViewCell {
         self.backgroundColor = .boxBg
         self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
-        self.layer.borderColor = UIColor.separator.cgColor
+        self.layer.borderColor = UIColor.boxBgLightModeStroke.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -44,7 +44,7 @@ final class HealthInfoStackCollectionViewCell: CoreCollectionViewCell {
         self.backgroundColor = .boxBg
         self.applyCornerStyle(.medium)
         self.layer.masksToBounds = false
-        self.layer.borderColor = UIColor.separator.cgColor
+        self.layer.borderColor = UIColor.boxBgLightModeStroke.cgColor
         self.layer.shadowColor = UIColor.black.cgColor
         self.layer.shadowOpacity = 0.15
         self.layer.shadowOffset = CGSize(width: 2, height: 2)

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -15,7 +15,8 @@ final class DashboardViewModel {
         let horizontalClassIsRegular: Bool
     }
 
-    private(set) var anchorDate: Date
+    let anchorDate: Date
+    let cameFromCalendar: Bool
 
     private(set) var goalRingIDs: [DailyGoalRingCellViewModel.ItemID] = []
     private(set) var goalRingCells: [DailyGoalRingCellViewModel.ItemID: DailyGoalRingCellViewModel] = [:]
@@ -39,8 +40,9 @@ final class DashboardViewModel {
     @Injected private var promptBuilderService: (any PromptBuilderService)
 
     ///
-    init(anchorDate: Date = .now) {
+    init(anchorDate: Date = .now, cameFromCalendar: Bool = false) {
         self.anchorDate = anchorDate
+        self.cameFromCalendar = cameFromCalendar
     }
 
 

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -16,7 +16,6 @@ final class DashboardViewModel {
     }
 
     let anchorDate: Date
-    let cameFromCalendar: Bool
 
     private(set) var goalRingIDs: [DailyGoalRingCellViewModel.ItemID] = []
     private(set) var goalRingCells: [DailyGoalRingCellViewModel.ItemID: DailyGoalRingCellViewModel] = [:]
@@ -33,6 +32,11 @@ final class DashboardViewModel {
     private(set) var chartsIDs: [DashboardBarChartsCellViewModel.ItemID] = []
     private(set) var chartsCells: [DashboardBarChartsCellViewModel.ItemID: DashboardBarChartsCellViewModel] = [:]
 
+    ///
+    private var shouldShowSummaryAndCharts: Bool {
+        anchorDate.isEqual(with: .now)
+    }
+
     private let alanService = AlanViewModel()
     @Injected private var goalStepService: GoalStepCountViewModel
     @Injected private var coreDataUserService: (any CoreDataUserService)
@@ -40,22 +44,20 @@ final class DashboardViewModel {
     @Injected private var promptBuilderService: (any PromptBuilderService)
 
     ///
-    init(anchorDate: Date = .now, cameFromCalendar: Bool = false) {
+    init(anchorDate: Date = .now) {
         self.anchorDate = anchorDate
-        self.cameFromCalendar = cameFromCalendar
     }
 
 
     // MARK: - Build Layout
 
-    ///
     func buildDashboardCells(for environment: DashboardEnvironment) {
         buildStackCells()
         buildGoalRingCells()
         buildCardCells()
 
         // 대시보드가 오늘자 데이터를 보여준다면
-        if anchorDate.isEqual(with: .now) {
+        if shouldShowSummaryAndCharts {
             buildAlanSummaryCells()
             buildBarChartsCells(for: environment)
         }
@@ -155,12 +157,16 @@ final class DashboardViewModel {
 
 extension DashboardViewModel {
 
-    func loadHKData(includeAISummary: Bool = true) {
+    func loadHKData() {
         loadHKDataForGoalRingCells()
         loadHKDataForStackCells()
-        if includeAISummary { loadAlanAIResponseForSummaryCells() }
         loadHKDataForCardCells()
         loadHKDataForBarChartsCells()
+
+        // 대시보드가 오늘자 데이터를 보여준다면
+        if shouldShowSummaryAndCharts {
+            loadAlanAIResponseForSummaryCells()
+        }
     }
 
     func loadHKDataForGoalRingCells() {


### PR DESCRIPTION
[Notion Task](https://www.notion.so/oreumi/HealthNavigationBar-255ebaa8982b805dbd66d37f806489cc?source=copy_link)

---

## ✅ 변경사항

- 대시보드에 `HealthNavigationBar` 코드를 적용하였습니다. 대시보드와 달력 모두 **스크롤을 해야지** 네비게이션 타이틀이 표시됩니다.
    1. 이는 의도된 구현입니다. 대시보드 화면은 이미 라지 타이틀(largeTitle)이 존재하기 때문에, 라지 타이틀과 네비게이션 타이틀이 모두 표시되면 굉장히 어색해 보이기 때문입니다.
    2. 이러한 구현은 다른 화면에서는 적용할 필요는 없어 보입니다.

- `HealthNavigationBar`에 타이틀을 숨길 수 있는 속성을 추가하였습니다. `isTitleLabelHidden`
- 대시보드 셀의 스트로크 색상을 `boxBgLightModeStroke`으로 수정하였습니다. 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-20 at 14 15 07" src="https://github.com/user-attachments/assets/5f81783c-9f53-4fa5-ad45-4578bec13c25" />  |   <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-20 at 14 14 54" src="https://github.com/user-attachments/assets/c50ea7cb-ab8a-42c7-bfa7-c178866ef8b9" /> |
| <img width="1640" height="2360" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2025-08-20 at 14 30 31" src="https://github.com/user-attachments/assets/4903ac04-36cb-46b9-b834-83dae2b59d1a" />   |  <img width="1640" height="2360" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2025-08-20 at 14 30 35" src="https://github.com/user-attachments/assets/bb47c117-c245-4888-85ec-ec652d37a701" /> |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-20 at 14 15 23](https://github.com/user-attachments/assets/fa853106-78d9-4e37-8de8-ef871ed0bd49) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-20 at 14 41 14](https://github.com/user-attachments/assets/2e5bd1a4-1add-402a-a4d4-9660eeb8b2c2)  |
