### PR TITLE
chore: 캘린더 탭 달력에 데이터가 없는 날짜셀은 테두리 제거

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -14,8 +14,8 @@ final class CalendarDateCell: CoreCollectionViewCell {
     private let borderLayer = CAShapeLayer()
 
     private var previousInset: CGFloat?
-    private var isBlankCell = false
-    private var isCompletedCell = false
+    private var isBlank = false
+    private var isCompleted = false
 
     private(set) var isSelectable = false
 
@@ -60,8 +60,8 @@ final class CalendarDateCell: CoreCollectionViewCell {
     // 셀 재사용 시 원래 상태 복원 보장
     override func prepareForReuse() {
         super.prepareForReuse()
-        isBlankCell = false
-        isCompletedCell = false
+        isBlank = false
+        isCompleted = false
         isSelectable = false
         contentView.alpha = 1.0
         contentView.transform = .identity
@@ -88,7 +88,7 @@ final class CalendarDateCell: CoreCollectionViewCell {
     func configure(date: Date, currentSteps: Int?, goalSteps: Int?) {
         // 빈 셀 처리
         if date == .distantPast {
-            isBlankCell = true
+            isBlank = true
             isSelectable = false
             configureForBlank()
             return
@@ -105,9 +105,9 @@ final class CalendarDateCell: CoreCollectionViewCell {
         }
 
         isSelectable = true
-        isCompletedCell = current >= goal
+        isCompleted = current >= goal
 
-        if isCompletedCell {
+        if isCompleted {
             circleView.backgroundColor = UIColor.accent
             progressBar.isHidden = true
         } else {
@@ -141,7 +141,7 @@ private extension CalendarDateCell {
     }
 
     func updateBorderLayer() {
-        let shouldShowBorder = traitCollection.userInterfaceStyle == .light && !isBlankCell && !isCompletedCell
+        let shouldShowBorder = traitCollection.userInterfaceStyle == .light && isSelectable && !isCompleted
 
         if shouldShowBorder {
             let borderWidth = bounds.width * 0.08


### PR DESCRIPTION
## 작업내용
- 캘린더 탭 달력 날짜셀에는 라이트모드에서만 보이는 테두리가 있습니다.
- 데이터가 없는 셀인지 현재 걸음 수가 0인 셀인지 구분할 수 없는 상태입니다.
- 따라서, 데이터가 없는 셀(= 클릭이 불가능한 셀)은 테두리를 제거했습니다.

## 스크린샷
| Before | After |
| -- | -- |
| <img width="340" height="359" alt="image" src="https://github.com/user-attachments/assets/0a24df01-ef6b-4764-b24f-858c2c8cc743" /> | <img width="337" height="357" alt="image" src="https://github.com/user-attachments/assets/d166a0e1-c1fa-4afe-8b76-5a1d78823223" /> |

## 링크
- [노션 태스크](https://www.notion.so/oreumi/255ebaa8982b8043bdbfc8db829c8ba6?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)