### PR TITLE
feat: 온보딩 볼드처리 로직 익스텐션 추가 및 적용 (라이트/다크모드 대응완료) + year 매서드 구현 완료

### DIFF
--- a/Health/Presentation/Onboarding/Cells/DiseaseCollectionViewCell.swift
+++ b/Health/Presentation/Onboarding/Cells/DiseaseCollectionViewCell.swift
@@ -21,38 +21,31 @@ class DiseaseCollectionViewCell: CoreCollectionViewCell {
     override func setupAttribute() {
         super.setupAttribute()
         contentView.backgroundColor = .boxBg
-        updateTextColor()
+        updateUIForCurrentState()
     }
     
     override var isSelected: Bool {
         didSet {
-            if isSelected {
-                contentView.backgroundColor = .accent
-                diseaseLabel.textColor = .black
-                diseaseLabel.font = UIFont.systemFont(ofSize: diseaseLabel.font.pointSize, weight: .bold)
-            } else {
-                contentView.backgroundColor = .boxBg
-                updateTextColor()
-                diseaseLabel.font = UIFont.systemFont(ofSize: diseaseLabel.font.pointSize, weight: .regular)
-            }
-        }
-    }
-    
-    private func updateTextColor() {
-        if traitCollection.userInterfaceStyle == .dark {
-            diseaseLabel.textColor = .white
-        } else {
-            diseaseLabel.textColor = UIColor(white: 0.2, alpha: 1)
+            updateUIForCurrentState()
         }
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if !isSelected {
-            updateTextColor()
+        updateUIForCurrentState()
+    }
+    
+    private func updateUIForCurrentState() {
+        let isDarkMode = traitCollection.userInterfaceStyle == .dark
+        
+        if isSelected {
+            contentView.backgroundColor = .accent
+            diseaseLabel.textColor = .black
+            diseaseLabel.font = diseaseLabel.font.withBoldTrait()
+        } else {
+            contentView.backgroundColor = .boxBg
+            diseaseLabel.textColor = isDarkMode ? .white : UIColor(white: 0.2, alpha: 1)
+            diseaseLabel.font = diseaseLabel.font.withNormalTrait()
         }
     }
 }
-
-
-

--- a/Health/Presentation/Onboarding/MainVC/DiseaseViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/DiseaseViewController.swift
@@ -45,7 +45,7 @@ class DiseaseViewController: CoreGradientViewController {
         continueButton.setTitle("다음", for: .normal)
         continueButton.applyCornerStyle(.medium)
         continueButton.isEnabled = false
-        continueButton.titleLabel?.numberOfLines = 1
+        updateButtonFont()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -114,6 +114,7 @@ class DiseaseViewController: CoreGradientViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateNavigationBarVisibility()
+        updateButtonFont()
     }
  
     private func updateNavigationBarVisibility() {
@@ -182,7 +183,17 @@ class DiseaseViewController: CoreGradientViewController {
         let enabled = selectedCount > 0
         continueButton.isEnabled = enabled
         continueButton.backgroundColor = enabled ? UIColor.accent : UIColor.buttonBackground
-        continueButton.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: enabled ? .bold : .regular)
+        updateButtonFont()
+    }
+    
+    private func updateButtonFont() {
+        if let currentFont = continueButton.titleLabel?.font {
+            if continueButton.isEnabled {
+                continueButton.titleLabel?.font = currentFont.withBoldTrait()
+            } else {
+                continueButton.titleLabel?.font = currentFont.withNormalTrait()
+            }
+        }
     }
 }
 

--- a/Health/Presentation/Onboarding/MainVC/InputAgeViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/InputAgeViewController.swift
@@ -49,6 +49,7 @@ class InputAgeViewController: CoreGradientViewController {
         registerForKeyboardNotifications()
         setupTapGestureToDismissKeyboard()
         disableContinueButton()
+        updateButtonFont()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -67,6 +68,11 @@ class InputAgeViewController: CoreGradientViewController {
         super.viewWillLayoutSubviews()
         updateContinueButtonConstraints()
         updateDescriptionTopConstraint()
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateButtonFont()
     }
     
     private func updateContinueButtonConstraints() {
@@ -143,7 +149,7 @@ class InputAgeViewController: CoreGradientViewController {
         guard let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else { return }
         
         ageInputFieldCenterY.constant = originalCenterY
-        continueButtonBottomConstraint.constant = -20
+        continueButtonBottomConstraint.constant = 0
         
         UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
@@ -211,14 +217,24 @@ class InputAgeViewController: CoreGradientViewController {
         continueButton.isEnabled = false
         continueButton.backgroundColor = .buttonBackground
         ageInputField.textColor = .label
-        continueButton.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .regular)
+        updateButtonFont()
     }
     
     private func enableContinueButton() {
         continueButton.isEnabled = true
         continueButton.backgroundColor = .accent
         ageInputField.textColor = .accent
-        continueButton.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .bold)
+        updateButtonFont()
+    }
+    
+    private func updateButtonFont() {
+        if let currentFont = continueButton.titleLabel?.font {
+            if continueButton.isEnabled {
+                continueButton.titleLabel?.font = currentFont.withBoldTrait()
+            } else {
+                continueButton.titleLabel?.font = currentFont.withNormalTrait()
+            }
+        }
     }
 
     private func fetchAndDisplayUserInfo() {

--- a/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
@@ -15,7 +15,6 @@ class StepGoalViewController: CoreGradientViewController {
     @IBOutlet weak var continueButtonLeading: NSLayoutConstraint!
     @IBOutlet weak var continueButtonTrailing: NSLayoutConstraint!
     @IBOutlet weak var stepGoalView: EditStepGoalView!
-    @IBOutlet weak var stepViewDescription: UILabel!
     @IBOutlet weak var stepGoalLeading: NSLayoutConstraint!
     @IBOutlet weak var stepGoalTrailing: NSLayoutConstraint!
     
@@ -40,12 +39,18 @@ class StepGoalViewController: CoreGradientViewController {
 
         stepGoalView.value = 0
         updateContinueButtonState()
+        updateButtonFont()
         
         if let parentVC = parent as? ProgressContainerViewController {
             parentVC.customNavigationBar.backButton.isHidden = true
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateButtonFont()
+    }
+    
     
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
@@ -87,7 +92,17 @@ class StepGoalViewController: CoreGradientViewController {
         let isValid = stepGoalView.value > 0
         continueButton.isEnabled = isValid
         continueButton.backgroundColor = isValid ? .accent : .buttonBackground
-        continueButton.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: isValid ? .bold : .regular)
+        updateButtonFont()
+    }
+    
+    private func updateButtonFont() {
+        if let currentFont = continueButton.titleLabel?.font {
+            if continueButton.isEnabled {
+                continueButton.titleLabel?.font = currentFont.withBoldTrait()
+            } else {
+                continueButton.titleLabel?.font = currentFont.withNormalTrait()
+            }
+        }
     }
     
     @IBAction func buttonAction(_ sender: Any) {

--- a/Health/Presentation/Onboarding/Onboarding.storyboard
+++ b/Health/Presentation/Onboarding/Onboarding.storyboard
@@ -62,6 +62,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="R7x-ei-F7n"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -109,24 +110,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZ1-Hk-BtZ" customClass="EditStepGoalView" customModule="Health" customModuleProvider="target">
                                 <rect key="frame" x="20" y="188" width="400" height="630"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목표 걸음 수를 설정 해주세요" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DiZ-i3-8js">
-                                        <rect key="frame" x="60" y="32" width="280" height="20.333333333333329"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                        </variation>
-                                    </label>
-                                </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstItem="DiZ-i3-8js" firstAttribute="centerX" secondItem="cZ1-Hk-BtZ" secondAttribute="centerX" id="4Ui-kE-zLS"/>
-                                    <constraint firstItem="DiZ-i3-8js" firstAttribute="top" secondItem="cZ1-Hk-BtZ" secondAttribute="top" constant="32" id="RBP-GQ-uSm"/>
-                                    <constraint firstItem="DiZ-i3-8js" firstAttribute="leading" secondItem="cZ1-Hk-BtZ" secondAttribute="leading" constant="60" id="rU3-BM-h4G"/>
-                                    <constraint firstAttribute="trailing" secondItem="DiZ-i3-8js" secondAttribute="trailing" constant="60" id="v4r-Gl-Mxz"/>
-                                </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MkJ-cU-nig">
                                 <rect key="frame" x="20" y="838" width="400" height="50"/>
@@ -134,6 +118,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="3pS-vA-UeY"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -166,7 +151,6 @@
                         <outlet property="stepGoalLeading" destination="mYI-kK-fki" id="RzP-57-xLE"/>
                         <outlet property="stepGoalTrailing" destination="Kt0-Tb-ZWY" id="6go-jD-Sbr"/>
                         <outlet property="stepGoalView" destination="cZ1-Hk-BtZ" id="bJO-LT-YSz"/>
-                        <outlet property="stepViewDescription" destination="DiZ-i3-8js" id="lcP-h7-m3u"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5SJ-I4-pXT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -225,7 +209,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                                 <variation key="heightClass=regular-widthClass=regular">
-                                    <fontDescription key="fontDescription" type="system" pointSize="50"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jVr-0Q-cfk">
@@ -234,7 +218,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                                 <variation key="heightClass=regular-widthClass=regular">
-                                    <fontDescription key="fontDescription" type="system" pointSize="50"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 </variation>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kfA-li-D6b">
@@ -243,6 +227,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="8ZB-fn-wPh"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -345,6 +330,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="LTV-1o-zTg"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -417,6 +403,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="vhQ-3h-HSJ"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -513,6 +500,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="slJ-ZO-VfC"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -641,6 +629,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="aeE-FA-HuA"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">
@@ -755,6 +744,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="dSS-ct-RNb"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="tintColor" name="AccentColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음">

--- a/Health/Presentation/Profile/Views/EditBirthdayView.swift
+++ b/Health/Presentation/Profile/Views/EditBirthdayView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 class EditBirthdayView: CoreView {
     
@@ -78,6 +79,30 @@ class EditBirthdayView: CoreView {
     func getSelectedYear() -> Int {
         return selectedYear
     }
+    
+    func updateYear() {
+            let context = CoreDataStack.shared.viewContext
+            let request: NSFetchRequest<UserInfoEntity> = UserInfoEntity.fetchRequest()
+            
+            do {
+                if let userInfo = try context.fetch(request).first, userInfo.age > 0 {
+                    let currentYear = Calendar.current.component(.year, from: Date())
+                    let calculatedYear = currentYear - Int(userInfo.age)
+                    setDefaultYear(calculatedYear)
+                }
+            } catch {
+                print("Core Data fetch 실패: \(error)")
+            }
+        }
+    
+    // MARK: - updateYear 사용 예제
+    /*
+    let birthdayView = EditBirthdayView()
+    birthdayView.updateYear()
+    print("생년: \(birthdayView.getSelectedYear())")
+    */
+    
+    
 }
 
 extension EditBirthdayView: UIPickerViewDataSource, UIPickerViewDelegate {


### PR DESCRIPTION
## #️⃣ 이슈번호

>

---

## ✅ 변경사항

-  온보딩 일부UI 볼드처리 라이트모드/다크모드 유지안되는 현상 수정
-  코어데이터의 age attributes 로부터 year 계산후 업데이트하는 함수 추가 (updateYear) 
- 에러텍스트 개선하면서 생긴 문제점 수정 (multiplier로 줘서 키보드 입력하거나 cmd k 반복할때 타이틀 위치 계속 내려가는 현상 수정   

---

## 🧪 테스트시 유의 사항

- 시뮬레이터상으로 다크모드/화이트모드 변동시 볼드처리확인이 안될수도있습니다. 볼드처리관련은 꼭 실기기로 봐주세요 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|    |     |

---

### 💜 결과

-
