### PR TITLE
feat: 캘린더 탭에 해당 탭을 설명하는 UI를 플로팅 시트로 추가

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+import TSAlertController
+
 final class CalendarViewController: HealthNavigationController {
 
     @IBOutlet weak var collectionView: UICollectionView!
@@ -70,15 +72,44 @@ final class CalendarViewController: HealthNavigationController {
 private extension CalendarViewController {
 
     func configureNavigationBar() {
+        let guideButton = HealthBarButtonItem(
+            image: UIImage(systemName: "info.circle"),
+            primaryAction: { [weak self] in
+                self?.showGuideView()
+            }
+        )
+
         let scrollToCurrentButton = HealthBarButtonItem(
             image: UIImage(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90"),
             primaryAction: { [weak self] in
                 self?.scrollManager.scrollToCurrentMonth(animated: true)
-            })
+            }
+        )
 
         healthNavigationBar.title = "캘린더"
         healthNavigationBar.titleImage = UIImage(systemName: "calendar")
-        healthNavigationBar.trailingBarButtonItems = [scrollToCurrentButton]
+        healthNavigationBar.trailingBarButtonItems = [guideButton, scrollToCurrentButton]
+    }
+
+    func showGuideView() {
+        let content = CalendarGuideView()
+
+        let alert = TSAlertController(
+            content,
+            options: [.dismissOnSwipeDown, .interactiveScaleAndDrag],
+            preferredStyle: .floatingSheet
+        )
+
+        let okAction = TSAlertAction(title: "확인")
+        okAction.highlightType = .fadeIn
+        okAction.configuration.backgroundColor = .accent
+        okAction.configuration.titleAttributes = [
+            .font: UIFont.preferredFont(forTextStyle: .headline),
+            .foregroundColor: UIColor.systemBackground
+        ]
+        alert.addAction(okAction)
+
+        present(alert, animated: true)
     }
 
     func configureBackground() {

--- a/Health/Presentation/Calendar/Views/CalendarGuideView.swift
+++ b/Health/Presentation/Calendar/Views/CalendarGuideView.swift
@@ -1,0 +1,101 @@
+import UIKit
+
+final class CalendarGuideView: UIView {
+
+    private struct Section {
+        let title: String
+        let description: String
+    }
+
+    private let sections: [Section] = [
+        Section(
+            title: "걸음 수 확인",
+            description: "각 날짜 원에서 목표 대비 진행률을 확인할 수 있으며, 달성 시 색상으로 강조됩니다."
+        ),
+        Section(
+            title: "대시보드 이동",
+            description: "데이터가 있는 날짜를 선택해서 열리는 대시보드를 통해 상세 정보를 확인할 수 있습니다."
+        ),
+        Section(
+            title: "데이터 출처",
+            description: "걸음 수는 건강 앱과 동기화되며, 연동이 꺼져 있으면 표시되지 않습니다."
+        )
+    ]
+
+	private let stackView = UIStackView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        setupStackView()
+        setupConstraints()
+        setupSections()
+    }
+
+    private func setupStackView() {
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 24
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24)
+        ])
+    }
+
+    private func setupSections() {
+        sections.forEach { section in
+            addSection(title: section.title, description: section.description)
+        }
+    }
+
+    private func addSection(title: String, description: String) {
+        let titleLabel = UILabel()
+        titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+        titleLabel.textColor = .label
+        titleLabel.numberOfLines = 0
+        titleLabel.text = title
+
+        let descLabel = createDescriptionLabel(text: description)
+
+        let vStack = UIStackView(arrangedSubviews: [titleLabel, descLabel])
+        vStack.axis = .vertical
+        vStack.spacing = 4
+
+        stackView.addArrangedSubview(vStack)
+    }
+
+    private func createDescriptionLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.numberOfLines = 0
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakStrategy = .hangulWordPriority
+
+        let attributedString = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .subheadline),
+                .foregroundColor: UIColor.secondaryLabel,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+
+        label.attributedText = attributedString
+        return label
+    }
+}


### PR DESCRIPTION
## 작업내용
- 캘린더 탭 네비게이션 바에 가이드 버튼을 추가했습니다.
- 해당 버튼을 클릭하면 캘린더 탭 이용에 관한 설명이 담긴 플로팅 시트가 열립니다.

## 스크린샷
| 캘린더 탭 | 버튼 클릭시 |
| -- | -- |
| |  |

## 링크
- [노션 태스크](https://www.notion.so/oreumi/UI-256ebaa8982b8063b849de571f5ebe74?source=copy_link)