### PR TITLE
feat: 대시보드 보행 밸런스 설명 시트 UI 개선, 실제 목표 걸음 수 데이터를 가져오도록 코드 수정

### DIFF
--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import TSAlertController
 
-final class DashboardViewController: HealthNavigationController {
+final class DashboardViewController: HealthNavigationController, Alertable {
 
     typealias DashboardDiffableDataSource = UICollectionViewDiffableDataSource<DashboardContent.Section, DashboardContent.Item>
 
@@ -54,11 +54,9 @@ final class DashboardViewController: HealthNavigationController {
 
         healthNavigationBar.title = "대시보드"
         healthNavigationBar.titleImage = UIImage(systemName: "chart.xyaxis.line")
-
         healthNavigationBar.trailingBarButtonItems = [
             HealthBarButtonItem(image: UIImage(systemName: "square.and.arrow.up.circle.fill"))
         ]
-        healthNavigationBar.preferredTrailingBarButtonItemSymbolConfiguration = UIImage.SymbolConfiguration(paletteColors: [.systemGray])
 
         refreshControl.addTarget(
             self,
@@ -268,7 +266,7 @@ fileprivate extension DashboardViewController {
     func createHealthInfoCardCellRegistration() -> UICollectionView.CellRegistration<HealthInfoCardCollectionViewCell, HealthInfoCardCellViewModel.ItemID> {
         UICollectionView.CellRegistration<HealthInfoCardCollectionViewCell, HealthInfoCardCellViewModel.ItemID>(cellNib: HealthInfoCardCollectionViewCell.nib) { [weak self] cell, indexPath, id in
             guard let vm = self?.viewModel.cardCells[id] else { return }
-            cell.bind(with: vm) // TODO: - 실제 CoreData에서 가져오기
+            cell.bind(with: vm)
         }
     }
 
@@ -290,7 +288,7 @@ fileprivate extension DashboardViewController {
             else { return }
 
             var reusableSupplementaryView = supplementaryView
-            let infoDetailBtn = InfoDetailButton(touchHandler: { [weak self] _ in self?.showWalkingBalanceAnaysisDescriptionsAlert() })
+            let infoDetailBtn = InfoDetailButton(touchHandler: { [weak self] _ in self?.showWalkingBalanceGuideSheet() })
             section.setContentConfiguration(
                 basicSupplementaryView: &reusableSupplementaryView,
                 detailButton: infoDetailBtn
@@ -301,34 +299,27 @@ fileprivate extension DashboardViewController {
 
 fileprivate extension DashboardViewController {
 
-    func showWalkingBalanceAnaysisDescriptionsAlert() {
-        let descsView = HeaderDescriptionsView()
-        descsView.descriptions = [
-            WalkingBalanceAnaysisString.stepLength,
-            WalkingBalanceAnaysisString.walkingSpeed,
-            WalkingBalanceAnaysisString.walkingAsymmetryPercentage,
-            WalkingBalanceAnaysisString.doubleSupportPercentage
+    func showWalkingBalanceGuideSheet() {
+        let sections = [
+            GuideSection(
+                title: "보행 속도",
+                description: WalkingBalanceAnaysisString.walkingSpeed
+            ),
+            GuideSection(
+                title: "보행 보폭",
+                description: WalkingBalanceAnaysisString.stepLength
+            ),
+            GuideSection(
+                title: "보행 비대칭성",
+                description: WalkingBalanceAnaysisString.walkingAsymmetryPercentage
+            ),
+            GuideSection(
+                title: "이중 지지 시간",
+                description: WalkingBalanceAnaysisString.doubleSupportPercentage
+            ),
         ]
+        let guideView = GuideView.create(with: sections)
 
-        let alert = TSAlertController(
-            descsView,
-            options: [.dismissOnSwipeDown, .interactiveScaleAndDrag],
-            preferredStyle: .floatingSheet
-        )
-
-        if traitCollection.verticalSizeClass == .regular
-            && traitCollection.horizontalSizeClass == .regular {
-            alert.preferredStyle = .alert
-            alert.viewConfiguration.size.width = .proportional(minimumRatio: 0.66, maximumRatio: 0.66)
-        }
-
-        let okAction = TSAlertAction(title: "확인")
-        okAction.highlightType = .fadeIn
-        okAction.configuration.backgroundColor = .accent
-        okAction.configuration.titleAttributes = [.font: UIFont.preferredFont(forTextStyle: .headline),
-                                                  .foregroundColor: UIColor.systemBackground]
-        alert.addAction(okAction)
-
-        present(alert, animated: true)
+        showFloatingSheet(guideView) { _ in }
     }
 }

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -427,11 +427,8 @@ extension DashboardViewModel {
     func fetchCoreDataUser() -> (age: Int, goalStep: Int) {
         // ⚠️ 사용자 및 목표 걸음 수가 제대로 등록되어 있으면 않으면 크래시
         let user = try! coreDataUserService.fetchUserInfo()
-//        let goalStepCount = goalStepService.goalStepCount(for: anchorDate.endOfDay())!
-//        return (Int(user.age), Int(goalStepCount))
-
-        // 🍓 온보딩 화면에서 '목표 걸음 수'를 입력 받기 전까지 임시 값 반환
-        return (Int(user.age), 10_000)
+        let goalStepCount = goalStepService.goalStepCount(for: anchorDate.endOfDay())!
+        return (Int(user.age), Int(goalStepCount))
     }
 }
 
@@ -501,13 +498,5 @@ fileprivate extension DashboardViewModel {
         case .monthsBack:
             return Calendar.current.date(byAdding: .month, value: value, to: date)
         }
-    }
-}
-
-
-fileprivate extension Array {
-
-    func prefix(maxLength convertToArrayImmediately: Int) -> [Element] {
-        Array(prefix(maxLength: convertToArrayImmediately))
     }
 }


### PR DESCRIPTION
## ✅ 변경사항

- 대시보드 보행 밸런스 설명 시트 UI를 개선했어요.
- 대시보드에서 실제 목표 걸음 수 데이터를 가져와 화면에 출력하도록 코드를 작성했어요. 

---

## 📝 참고

- 다음 PR에 할 일: 프로필 화면에서 목표 걸음 수 갱신 시, 대시보드 다시 로드하도록 하기

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="1640" height="2360" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2025-08-22 at 10 04 28" src="https://github.com/user-attachments/assets/449e801f-2f80-47b5-939a-bdef3e8dfff7" />  |  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-22 at 10 03 45" src="https://github.com/user-attachments/assets/b8ea8f1f-be8f-46a5-91df-d3c95e77049e" />
   |

---
