### PR TITLE
feat: 버튼 하이라이트추가 + 헬스킷 로직 변경 (PR설명 참고)

### DIFF
--- a/Health/Presentation/Onboarding/MainVC/DiseaseViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/DiseaseViewController.swift
@@ -42,10 +42,29 @@ class DiseaseViewController: CoreGradientViewController {
         applyBackgroundGradient(.midnightBlack)
         setupCollectionView()
         
-        continueButton.setTitle("다음", for: .normal)
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
+            }
+        }
+        continueButton.configuration = config
         continueButton.applyCornerStyle(.medium)
         continueButton.isEnabled = false
-        updateButtonFont()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -114,7 +133,6 @@ class DiseaseViewController: CoreGradientViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateNavigationBarVisibility()
-        updateButtonFont()
     }
  
     private func updateNavigationBarVisibility() {
@@ -183,17 +201,6 @@ class DiseaseViewController: CoreGradientViewController {
         let enabled = selectedCount > 0
         continueButton.isEnabled = enabled
         continueButton.backgroundColor = enabled ? UIColor.accent : UIColor.buttonBackground
-        updateButtonFont()
-    }
-    
-    private func updateButtonFont() {
-        if let currentFont = continueButton.titleLabel?.font {
-            if continueButton.isEnabled {
-                continueButton.titleLabel?.font = currentFont.withBoldTrait()
-            } else {
-                continueButton.titleLabel?.font = currentFont.withNormalTrait()
-            }
-        }
     }
 }
 

--- a/Health/Presentation/Onboarding/MainVC/GenderSelectViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/GenderSelectViewController.swift
@@ -49,6 +49,27 @@ class GenderSelectViewController: CoreGradientViewController {
         super.viewDidLoad()
         applyBackgroundGradient(.midnightBlack)
         
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
+            }
+        }
+        continueButton.configuration = config
         continueButton.applyCornerStyle(.medium)
         continueButton.addTarget(self, action: #selector(continueButtonTapped), for: .touchUpInside)
 

--- a/Health/Presentation/Onboarding/MainVC/HeightViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/HeightViewController.swift
@@ -42,8 +42,28 @@ class HeightViewController: CoreGradientViewController {
         errorLabel.isHidden = true
         errorLabel.textColor = .red
         
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
+            }
+        }
+        continueButton.configuration = config
         continueButton.applyCornerStyle(.medium)
-        updateButtonFont()
         
         originalCenterY = heightInputFieldCenterY.constant
         originalDescriptionTop = descriptionLabelTopConst.constant
@@ -71,11 +91,6 @@ class HeightViewController: CoreGradientViewController {
         super.viewWillLayoutSubviews()
         updateContinueButtonConstraints()
         updateDescriptionTopConstraint()
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateButtonFont()
     }
     
     private func updateDescriptionTopConstraint() {
@@ -240,24 +255,12 @@ class HeightViewController: CoreGradientViewController {
         continueButton.isEnabled = false
         continueButton.backgroundColor = .buttonBackground
         heightInputField.textColor = .label
-        updateButtonFont()
     }
     
     private func enableContinueButton() {
         continueButton.isEnabled = true
         continueButton.backgroundColor = .accent
         heightInputField.textColor = .accent
-        updateButtonFont()
-    }
-    
-    private func updateButtonFont() {
-        if let currentFont = continueButton.titleLabel?.font {
-            if continueButton.isEnabled {
-                continueButton.titleLabel?.font = currentFont.withBoldTrait()
-            } else {
-                continueButton.titleLabel?.font = currentFont.withNormalTrait()
-            }
-        }
     }
     
     private func fetchUserInfo() {

--- a/Health/Presentation/Onboarding/MainVC/OnboardingViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/OnboardingViewController.swift
@@ -24,10 +24,33 @@ class OnboardingViewController: CoreGradientViewController {
         super.viewDidLoad()
         
         applyBackgroundGradient(.midnightBlack)
-
-        continueButton.applyCornerStyle(.medium)
+        
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
+            }
+        }
+        
+        continueButton.configuration = config
         continueButton.isEnabled = true
         continueButton.addTarget(self, action: #selector(buttonAction(_:)), for: .touchUpInside)
+        continueButton.applyCornerStyle(.medium)
+        continueButton.translatesAutoresizingMaskIntoConstraints = false
 
         appImageView.image = UIImage(named: "appIconAny")
         appImageView.contentMode = .scaleAspectFit

--- a/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
@@ -39,7 +39,6 @@ class StepGoalViewController: CoreGradientViewController {
 
         stepGoalView.value = 0
         updateContinueButtonState()
-        updateButtonFont()
         
         if let parentVC = parent as? ProgressContainerViewController {
             parentVC.customNavigationBar.backButton.isHidden = true
@@ -48,7 +47,6 @@ class StepGoalViewController: CoreGradientViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateButtonFont()
     }
     
     
@@ -90,19 +88,29 @@ class StepGoalViewController: CoreGradientViewController {
     
     @objc private func updateContinueButtonState() {
         let isValid = stepGoalView.value > 0
-        continueButton.isEnabled = isValid
-        continueButton.backgroundColor = isValid ? .accent : .buttonBackground
-        updateButtonFont()
-    }
-    
-    private func updateButtonFont() {
-        if let currentFont = continueButton.titleLabel?.font {
-            if continueButton.isEnabled {
-                continueButton.titleLabel?.font = currentFont.withBoldTrait()
-            } else {
-                continueButton.titleLabel?.font = currentFont.withNormalTrait()
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
             }
         }
+        continueButton.configuration = config
+        continueButton.isEnabled = isValid
+        continueButton.backgroundColor = isValid ? .accent : .buttonBackground
     }
     
     @IBAction func buttonAction(_ sender: Any) {

--- a/Health/Presentation/Onboarding/MainVC/WeightViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/WeightViewController.swift
@@ -42,6 +42,27 @@ class WeightViewController: CoreGradientViewController {
         errorLabel.isHidden = true
         errorLabel.textColor = .red
         
+        var config = UIButton.Configuration.filled()
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var out = incoming
+            out.font = UIFont.preferredFont(forTextStyle: .headline)
+            return out
+        }
+        config.baseBackgroundColor = .accent
+        config.baseForegroundColor = .systemBackground
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .headline)
+        config.attributedTitle = AttributedString("다음", attributes: container)
+            
+        continueButton.configurationUpdateHandler = { [weak self] button in
+            switch button.state
+            {
+            case .highlighted:
+                self?.continueButton.alpha = 0.75
+            default: self?.continueButton.alpha = 1.0
+            }
+        }
+        continueButton.configuration = config
         continueButton.applyCornerStyle(.medium)
         
         originalCenterY = weightInputFieldCenterY.constant
@@ -57,9 +78,6 @@ class WeightViewController: CoreGradientViewController {
         } else {
             disableContinueButton()
         }
-        
-        // viewDidLoad에서 폰트 업데이트를 호출
-        updateButtonFont()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -73,11 +91,6 @@ class WeightViewController: CoreGradientViewController {
         super.viewWillLayoutSubviews()
         updateContinueButtonConstraints()
         updateDescriptionTopConstraint()
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateButtonFont()
     }
     
     private func updateDescriptionTopConstraint() {
@@ -239,28 +252,17 @@ class WeightViewController: CoreGradientViewController {
         errorLabel.text = ""
     }
     
-    private func updateButtonFont() {
-        if let currentFont = continueButton.titleLabel?.font {
-            if continueButton.isEnabled {
-                continueButton.titleLabel?.font = currentFont.withBoldTrait()
-            } else {
-                continueButton.titleLabel?.font = currentFont.withNormalTrait()
-            }
-        }
-    }
     
     private func disableContinueButton() {
         continueButton.isEnabled = false
         continueButton.backgroundColor = .buttonBackground
         weightInputField.textColor = .label
-        updateButtonFont()
     }
     
     private func enableContinueButton() {
         continueButton.isEnabled = true
         continueButton.backgroundColor = .accent
         weightInputField.textColor = .accent
-        updateButtonFont()
     }
     
     private func fetchUserInfo() {


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- continue버튼 하이라이트 추가 (기존 볼드처리로직 제거하고, 볼드인상태에서 하이라이트적용)

- **중요 변동사항 ⭐️⭐️⭐️**

기존 연동 로직
- 사용자에게 설정앱으로 이동하는 경고창을띄워 강제적으로 설정앱으로 이동하게만들어서
 사용자에게 무조건 권한을 설정해야된다의 느낌의 로직
 
- 연동안하고 넘어갈때, 사용자에게 연동설정에관한 알람창을 띄웠었음 

수정후 
- 사용자에게 권한설정알람을 띄워줬을때, 알람창 하단에 선택하는 분기 설정 

앱 작동이 정상적으로안될수도있습니다. 연동하실겁니까? 
                      취소(온보딩 계속 진행) / 설정으로 이동 
                      

- 기존 다음 버튼을 눌렀을때, 사용자에게 다시 연동설정에 관한 알람창을 띄웠으나, 이제 스위치만 눌러도 사용자에게 물어보고 분기점을 
나눔으로서, 이부분은 개발자의 의도가 중복되므로 기존에 다음버튼눌렀을때 알람창띄우는 로직은 삭제

- 화면을 날리거나, 설정화면으로 이동했다가 다시 들어왔을때 스위치가 켜져있는것도확인. (연동성공시) 
- 설정앱이아닌, 바로 건강앱으로 갈수있게 일단은 구현, 이부분은 추후 논의사항에 의해 다시 설정앱이동으로 변동될가능성있어
이전코드는 주석처리 
---

## 🧪 테스트시 유의 사항

- 꼭 실기기로 확인하셔야합니다. 시뮬레이터상으론 스위치가 살아있는지 죽어있는지 연동이안되서 확인불가능이에요 

---

## 📝 참고

- 

---

## 🌈 이미지

<img width="1170" height="2532" alt="IMG_4247" src="https://github.com/user-attachments/assets/fdaba19c-bcbe-4f16-aec2-a92e2e522d52" />

---

### 💜 결과

-
