### PR TITLE
feat: `didChangeHKSharingAuthorizationStatus` 노티피케이션 생성 및 포그라운드에 진입할 때마다 신호를 전달하도록 코드 구현

### DIFF
--- a/Health/Core/Utils/AnyHashable+UserInfo.swift
+++ b/Health/Core/Utils/AnyHashable+UserInfo.swift
@@ -1,0 +1,13 @@
+//
+//  AnyHashable+UserInfo.swift
+//  Health
+//
+//  Created by 김건우 on 8/22/25.
+//
+
+import Foundation
+
+extension AnyHashable {
+    
+    nonisolated(unsafe) static let status: AnyHashable = "status"
+}

--- a/Health/Core/Utils/Notification+Name.swift
+++ b/Health/Core/Utils/Notification+Name.swift
@@ -11,4 +11,11 @@ extension Notification.Name {
 
     /// 프로필 화면에서 `목표 걸음 수` 데이터가 갱신되었음을 알리는 알림 이름입니다.
     static let didUpdateGoalStepCount = Notification.Name("didUpdateGoalStepCount")
+    
+    /// HealthKit 권한 상태가 변경되었음을 알리는 알림 이름입니다.
+    ///
+    /// `userInfo[.status]` 값이 `true`라면 필요한 데이터 읽기가 하나라도 허용된 상태를 의미합니다.
+    /// `false`라면 하나 이상의 권한이 부족하여 일부 데이터를 읽을 수 없음을 의미합니다.
+    /// 최초 앱 실행 시에는 전달되지 않으며, 앱 내부 또는 외부에서 권한 상태가 실제로 변경되었을 때만 게시됩니다.
+    static let didChangeHKSharingAuthorizationStatus = Notification.Name("didChangeHKAuthorizationStatus")
 }

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -94,6 +94,13 @@ final class DashboardViewController: HealthNavigationController, Alertable {
             name: .didUpdateGoalStepCount,
             object: nil
         )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshHKData),
+            name: .didChangeHKSharingAuthorizationStatus,
+            object: nil
+        )
     }
 
     @objc private func refreshHKData() {


### PR DESCRIPTION
@giseungNoh 
@haejaejoon 
@jseongee 

## ✅ 변경사항

- `didChangeHKSharingAuthorizationStatus` 노티피케이션 생성 및 포그라운드에 진입할 때마다 적절히 신호를 전달하도록 코드 구현하였습니다.

> ⚠️ 최초 앱 실행 시,  `didChangeHKSharingAuthorizationStatus` 노티피케이션 신호가 방출되지 않습니다. 오직, 앱 외부에서 건강 데이터 읽기 권한에 실질적인 변화가 생겼을 때만 신호를 방출하며, 동일한 신호가 연속으로 방출되지 않습니다. 이는 무차별적인 신호 방출로 빈번히 화면이 리프레쉬되는 상황을 막기 위함입니다. 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
| <img width="795" height="77" alt="스크린샷 2025-08-22 오후 7 05 24" src="https://github.com/user-attachments/assets/7224f528-2ed9-4c60-9e09-a77a5f6ce45a" />   |    ![ScreenRecording_08-22-2025 19-15-31_1](https://github.com/user-attachments/assets/b573f705-b171-4780-8b91-7d9f6db910a3) |

---

### 💜 결과


