### PR TITLE
feat:추천코스와 MapKit 연결 및 경로 안내

### DIFF
--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
@@ -10,6 +10,7 @@ import MapKit
 
 protocol RecommendPlaceCellDelegate: AnyObject {
     func didTapInfoButton(for course: WalkingCourse)
+    func didTapCell(for course: WalkingCourse)
 }
 
 class RecommendPlaceCell: CoreCollectionViewCell {
@@ -32,7 +33,7 @@ class RecommendPlaceCell: CoreCollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
+        setupTapGesture()
     }
 
     override func setupAttribute() {
@@ -125,6 +126,17 @@ class RecommendPlaceCell: CoreCollectionViewCell {
                 .applyingSymbolConfiguration(.init(paletteColors: [.info]))
             infoButton.configuration = config
         }
+    }
+
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
+        self.addGestureRecognizer(tapGesture)
+        self.isUserInteractionEnabled = true
+    }
+
+    @objc private func cellTapped() {
+        guard let course = currentCourse else { return }
+        delegate?.didTapCell(for: course)
     }
 }
 

--- a/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
@@ -67,9 +67,9 @@ final class CourseInfoView: UIView {
         let messageLabel = UILabel()
         messageLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
         messageLabel.textColor = .warningSymbol
-        messageLabel.text = "코스난이도는 사용자의 신체정보를 바탕으로 추천됩니다"
+        messageLabel.text = "코스난이도는 사용자의 신체정보를 바탕으로 추천됩니다."
         messageLabel.textAlignment = .center
-        messageLabel.numberOfLines = 1
+        messageLabel.numberOfLines = 0
         stackView.addArrangedSubview(messageLabel)
      }
 

--- a/Health/Presentation/Personal/Views/SubView/CourseViewController.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseViewController.swift
@@ -1,0 +1,289 @@
+//
+//  CourseViewController.swift
+//  Health
+//
+//  Created by juks86 on 8/22/25.
+//
+
+import UIKit
+import MapKit
+import TSAlertController
+
+class MapViewController: UIViewController,Alertable {
+    var courseCoordinates: [CLLocationCoordinate2D] = []
+    var courseInfo: WalkingCourse?
+
+    @IBOutlet weak var mapView: MKMapView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupMapView()
+        setupMap()
+        setupCloseButton()
+    }
+
+    private func setupMapView() {
+        mapView.delegate = self // delegate 설정
+    }
+
+    private func setupCloseButton() {
+        // 제목 설정
+        if let courseInfo = courseInfo {
+            title = courseInfo.crsKorNm
+        } else {
+            title = "코스 경로"
+        }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .close,
+            target: self,
+            action: #selector(closeButtonTapped)
+        )
+
+        // 왼쪽 버튼 제거
+        navigationItem.leftBarButtonItem = nil
+    }
+
+    @objc private func closeButtonTapped() {
+        dismiss(animated: true)
+    }
+
+    private func setupMap() {
+        guard !courseCoordinates.isEmpty else { return }
+
+        let polyline = MKPolyline(coordinates: courseCoordinates, count: courseCoordinates.count)
+        mapView.addOverlay(polyline)
+
+        // 시작점과 종점 좌표 확인
+        if let startCoordinate = courseCoordinates.first,
+           let endCoordinate = courseCoordinates.last {
+
+            let startLocation = CLLocation(latitude: startCoordinate.latitude, longitude: startCoordinate.longitude)
+            let endLocation = CLLocation(latitude: endCoordinate.latitude, longitude: endCoordinate.longitude)
+            let distance = startLocation.distance(from: endLocation)
+
+            // 50미터 이내면 같은 지점으로 간주
+            if distance < 50 {
+                // 하나의 마커만 표시 (순환 코스)
+                let circuitAnnotation = MKPointAnnotation()
+                circuitAnnotation.coordinate = startCoordinate
+                circuitAnnotation.title = "출발/도착"
+                mapView.addAnnotation(circuitAnnotation)
+            } else {
+                // 별도 마커 표시
+                let startAnnotation = MKPointAnnotation()
+                startAnnotation.coordinate = startCoordinate
+                startAnnotation.title = "시작점"
+                mapView.addAnnotation(startAnnotation)
+
+                let endAnnotation = MKPointAnnotation()
+                endAnnotation.coordinate = endCoordinate
+                endAnnotation.title = "종점"
+                mapView.addAnnotation(endAnnotation)
+            }
+        }
+
+        mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: UIEdgeInsets(top: 50, left: 50, bottom: 50, right: 50), animated: false)
+    }
+
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        let identifier = "CoursePoint"
+        var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
+
+        if annotationView == nil {
+            annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+        } else {
+            annotationView?.annotation = annotation
+        }
+
+        if let markerView = annotationView as? MKMarkerAnnotationView {
+            if annotation.title == "시작점" {
+                markerView.markerTintColor = .systemGreen
+                markerView.glyphText = "S"
+            } else if annotation.title == "종점" {
+                markerView.markerTintColor = .systemRed
+                markerView.glyphText = "E"
+            }
+        }
+
+        return annotationView
+    }
+}
+
+// MARK: - MKMapViewDelegate
+extension MapViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if let polyline = overlay as? MKPolyline {
+            let renderer = MKPolylineRenderer(polyline: polyline)
+            renderer.strokeColor = .systemBlue
+            renderer.lineWidth = 3.0
+            renderer.lineCap = .round
+            renderer.lineJoin = .round
+            return renderer
+        }
+        return MKOverlayRenderer(overlay: overlay)
+    }
+
+    func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        if view.annotation?.title == "시작점" || view.annotation?.title == "출발/도착" {
+            showDirectionsActionSheet()
+        }
+        mapView.deselectAnnotation(view.annotation, animated: false)
+    }
+
+    private func showDirectionsActionSheet() {
+        let actionSheetView = createDirectionsActionSheetView()
+
+        showActionSheet(
+            actionSheetView,
+            confirmTitle: "닫기",
+            onConfirmAction: { _ in }
+        )
+    }
+
+    private func createDirectionsActionSheetView() -> UIView {
+        let containerView = UIView()
+        containerView.backgroundColor = .clear
+
+        let mainStackView = UIStackView()
+        mainStackView.axis = .vertical
+        mainStackView.spacing = 16
+        mainStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        // 제목 추가
+        let titleLabel = UILabel()
+        titleLabel.text = "경로 안내"
+        titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+        titleLabel.textAlignment = .center
+        titleLabel.textColor = .label
+
+        // 수평 스택뷰로 버튼 배치
+        let buttonStackView = UIStackView()
+        buttonStackView.axis = .horizontal
+        buttonStackView.spacing = 12
+        buttonStackView.distribution = .fillEqually
+
+        // 도보 버튼 배경
+        let walkingBackgroundView = UIView()
+        walkingBackgroundView.backgroundColor = .boxBg
+        walkingBackgroundView.layer.cornerRadius = 12
+
+        let walkingButton = createDirectionButton(title: "도보", systemImage: "figure.walk", mode: MKLaunchOptionsDirectionsModeWalking)
+        walkingBackgroundView.addSubview(walkingButton)
+
+        // 자동차 버튼 배경
+        let drivingBackgroundView = UIView()
+        drivingBackgroundView.backgroundColor = .boxBg
+        drivingBackgroundView.layer.cornerRadius = 12
+
+        let drivingButton = createDirectionButton(title: "자동차", systemImage: "car.fill", mode: MKLaunchOptionsDirectionsModeDriving)
+        drivingBackgroundView.addSubview(drivingButton)
+
+        // 제약조건 설정
+        walkingButton.translatesAutoresizingMaskIntoConstraints = false
+        drivingButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            walkingButton.topAnchor.constraint(equalTo: walkingBackgroundView.topAnchor, constant: 8),
+            walkingButton.leadingAnchor.constraint(equalTo: walkingBackgroundView.leadingAnchor, constant: 8),
+            walkingButton.trailingAnchor.constraint(equalTo: walkingBackgroundView.trailingAnchor, constant: -8),
+            walkingButton.bottomAnchor.constraint(equalTo: walkingBackgroundView.bottomAnchor, constant: -8),
+
+            drivingButton.topAnchor.constraint(equalTo: drivingBackgroundView.topAnchor, constant: 8),
+            drivingButton.leadingAnchor.constraint(equalTo: drivingBackgroundView.leadingAnchor, constant: 8),
+            drivingButton.trailingAnchor.constraint(equalTo: drivingBackgroundView.trailingAnchor, constant: -8),
+            drivingButton.bottomAnchor.constraint(equalTo: drivingBackgroundView.bottomAnchor, constant: -8)
+        ])
+
+        buttonStackView.addArrangedSubview(walkingBackgroundView)
+        buttonStackView.addArrangedSubview(drivingBackgroundView)
+
+        // 메인 스택뷰에 제목과 버튼 추가
+        mainStackView.addArrangedSubview(titleLabel)
+        mainStackView.addArrangedSubview(buttonStackView)
+
+        containerView.addSubview(mainStackView)
+
+        NSLayoutConstraint.activate([
+            mainStackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+            mainStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8)
+        ])
+
+        return containerView
+    }
+
+    private func createDirectionButton(title: String, systemImage: String, mode: String) -> UIButton {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.title = title
+        config.image = UIImage(systemName: systemImage)
+        config.imagePlacement = .leading
+        config.imagePadding = 12
+        config.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
+
+        button.configuration = config
+        button.contentHorizontalAlignment = .center
+        button.addTarget(self, action: #selector(directionButtonTapped(_:)), for: .touchUpInside)
+        button.tag = mode.hashValue
+
+        // 하이라이트 효과
+        button.configurationUpdateHandler = { button in
+            switch button.state {
+            case .highlighted:
+                button.alpha = 0.75
+            default:
+                button.alpha = 1.0
+            }
+        }
+
+        return button
+    }
+
+    @objc private func directionButtonTapped(_ sender: UIButton) {
+        let mode: String
+        let modeTitle: String
+
+        switch sender.tag {
+        case MKLaunchOptionsDirectionsModeWalking.hashValue:
+            mode = MKLaunchOptionsDirectionsModeWalking
+            modeTitle = "도보"
+        case MKLaunchOptionsDirectionsModeDriving.hashValue:
+            mode = MKLaunchOptionsDirectionsModeDriving
+            modeTitle = "자동차"
+        default:
+            return
+        }
+
+        // 액션시트 먼저 닫기
+        presentedViewController?.dismiss(animated: true) {
+            // 알림창 표시
+            self.showAlert(
+                "경로 안내",
+                message: "Apple Maps에서 \(modeTitle) 길찾기를 실행하시겠습니까?",
+                primaryTitle: "확인",
+                onPrimaryAction: { _ in
+                    self.startDirections(mode: mode)
+                },
+                cancelTitle: "취소",
+                onCancelAction: { _ in
+                }
+            )
+        }
+    }
+
+    private func startDirections(mode: String) {
+        guard let startCoordinate = courseCoordinates.first else { return }
+
+        let placemark = MKPlacemark(coordinate: startCoordinate)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = courseInfo?.crsKorNm ?? "코스 시작점"
+
+        let launchOptions = [
+            MKLaunchOptionsDirectionsModeKey: mode
+        ]
+
+        mapItem.openInMaps(launchOptions: launchOptions)
+    }
+}

--- a/Health/Presentation/Personal/Views/SubView/DetailCourse.storyboard
+++ b/Health/Presentation/Personal/Views/SubView/DetailCourse.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Map view configurations" minToolsVersion="14.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Map View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="DetailCourse" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="MapViewController" customModule="Health" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EB7-TN-pkz">
+                                <rect key="frame" x="0.0" y="118" width="393" height="734"/>
+                                <standardMapConfiguration key="preferredConfiguration"/>
+                            </mapView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="EB7-TN-pkz" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="OgA-TF-2uD"/>
+                            <constraint firstAttribute="bottom" secondItem="EB7-TN-pkz" secondAttribute="bottom" id="fMz-hr-dad"/>
+                            <constraint firstItem="EB7-TN-pkz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="p9g-JX-6w5"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="EB7-TN-pkz" secondAttribute="trailing" id="vI8-V8-wWa"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="mapView" destination="EB7-TN-pkz" id="jVJ-Gb-6eI"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="90.839694656488547" y="-34.507042253521128"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Health/Services/CourseService/LocationPermissionService.swift
+++ b/Health/Services/CourseService/LocationPermissionService.swift
@@ -127,7 +127,6 @@ extension LocationPermissionService: CLLocationManagerDelegate {
         Task { @MainActor in
             guard let location = locations.last else { return }
 
-            // ✅ '보안 구역' 안에서 안전하게 물건을 만지는 중
             self.cachedLocation = location
             self.lastLocationTime = Date()
             self.locationContinuation?.resume(returning: location)


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 추천코스셀 클릭시 경로가 표시된 Map으로 이동합니다.
- 경로에서 시점을 클릭하면 경로안내를 받을 수 있습니다.
- 원본과 우회로 2개의 GPX 데이터를 받아올때가 있어 폴리라인이 비정상적으로 그려지는 버그를 발견하여 버그 수정했습니다.
-시점과 종점이 같으면 시점/종점으로 표시됩니다.
---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
<img width="393" height="852" alt="IMG_7117" src="https://github.com/user-attachments/assets/a1afc42b-755c-407c-9998-85fbd05b8408" />
<img width="820" height="1180" alt="IMG_0741" src="https://github.com/user-attachments/assets/2ea19086-01a6-4d99-9c8b-166c527b9557" />
<img width="820" height="1180" alt="IMG_0742" src="https://github.com/user-attachments/assets/e0e3e531-bd3b-492b-a066-f8232274be05" />
|    |     |

---

### 💜 결과

-
