### PR TITLE
fix:코스 경로 라이트모드로 고정 및 좌표값 캐싱 추가

### DIFF
--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
@@ -65,7 +65,7 @@ class RecommendPlaceCell: CoreCollectionViewCell {
         distanceLabel.text = "\(course.crsDstnc)km"
         durationLabel.text = course.crsTotlRqrmHour.toFormattedDuration()
         // 난이도 텍스트와 이미지 색상 동시 설정
-        let levelInfo = getLevelText(from: course.crsLevel)
+        let levelInfo = getLevelInfo(from: course.crsLevel)
         levelLabel.text = levelInfo.text
         levelImage.tintColor = levelInfo.color
 
@@ -112,7 +112,7 @@ class RecommendPlaceCell: CoreCollectionViewCell {
     }
 
     // 난이도 변환 함수
-    func getLevelText(from level: String) -> (text: String, color: UIColor) {
+    func getLevelInfo(from level: String) -> (text: String, color: UIColor) {
         switch level {
         case "1":
             return ("쉬움", .systemYellow) // 쉬움: 노란색

--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
@@ -207,6 +207,7 @@
                 <outlet property="distanceLabel" destination="vqH-Y3-HTf" id="vjo-hp-8CX"/>
                 <outlet property="durationLabel" destination="K1g-4l-9EY" id="SkA-ay-F5b"/>
                 <outlet property="infoButton" destination="CzL-G7-iQS" id="hPU-0h-Ug7"/>
+                <outlet property="levelImage" destination="9gA-Ma-LIY" id="bfy-ET-KaD"/>
                 <outlet property="levelLabel" destination="aR8-eQ-5SL" id="0V2-1w-JnX"/>
                 <outlet property="locationLabel" destination="59X-R2-pzI" id="UB4-kN-TL0"/>
                 <outlet property="placeBackground" destination="MzM-wC-y0u" id="1MY-1d-4vM"/>


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 코스 경로는 라이트 모드로 고정 시켰습니다
-> 라이트모드, 다크모드일때 즉각적으로 바뀌기 위해서는 결국 라이트 모드일때와 다크모드일때의 지도 스냅샷을 두번 만들어야해서 비효율적이고 이미지 생성되는게 너무 느려서 라이트모드로 고정시켰습니다.

-난이도가 쉬움이면 노랑색, 보통이면 주황색, 어려움이면 빨간색으로 표시됩니다.

-GPX 좌표값 캐싱 추가

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
<img width="382" height="852" alt="IMG_7129" src="https://github.com/user-attachments/assets/f819ad0f-5800-47fd-82fe-d8a7d9dcdf3b" />
<img width="382" height="852" alt="IMG_7130" src="https://github.com/user-attachments/assets/c54936d9-08d5-47e3-92f9-4e9cb75f9f0e" />
|    |     |

---

### 💜 결과

-
