### PR TITLE
fix: 건강 앱 연동을 해제해도 캘린더 탭 달력에 데이터가 표시되는 문제 수정

### DIFF
--- a/Health/Core/CoreGradientViewController.swift
+++ b/Health/Core/CoreGradientViewController.swift
@@ -42,7 +42,6 @@ class CoreGradientViewController: CoreViewController {
 		
 		if #available(iOS 13.0, *) {
 			let isDarkMode = traitCollection.userInterfaceStyle == .dark
-			print("[\(String(describing: type(of: self)))] 그라디언트 적용: \(gradientType.rawValue), 다크모드: \(isDarkMode)")
 		}
 	}
 	
@@ -52,8 +51,6 @@ class CoreGradientViewController: CoreViewController {
 		currentGradientType = nil
 		view.removeGradientBackground()
 		view.backgroundColor = color
-		
-		print("[\(String(describing: type(of: self)))] 단색 배경 적용: \(color)")
 	}
 	
 	/// 다이나믹 컬러를 cgColor로 변환

--- a/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
+++ b/Health/Core/NavigationBar/HealthNavigationBar/HealthNavigationBar.swift
@@ -123,7 +123,6 @@ final class HealthNavigationBar: CoreView {
         guard let items = trailingBarButtonItems else { return }
         trailingBarItemsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         layoutTrailingBarButtonItems(items)
-        print(trailingBarItemsStackView.bounds.height)
     }
 
     private func layoutNavigationBar(_ vc: UIViewController, nav: UINavigationController?) {

--- a/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarMonthCell.swift
@@ -9,6 +9,7 @@ final class CalendarMonthCell: CoreCollectionViewCell {
     @Injected(.calendarStepService) private var stepService: CalendarStepService
 
     private var datesWithBlank: [Date] = []
+    private var isStepCountAuthorized = false
 
     var onDateSelected: ((Date) -> Void)?
 
@@ -23,7 +24,8 @@ final class CalendarMonthCell: CoreCollectionViewCell {
         )
     }
 
-    func configure(with monthData: CalendarMonthData) {
+    func configure(with monthData: CalendarMonthData, isStepCountAuthorized: Bool) {
+        self.isStepCountAuthorized = isStepCountAuthorized
         setupMonthData(year: monthData.year, month: monthData.month)
     }
 
@@ -59,9 +61,16 @@ extension CalendarMonthCell: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarDateCell.id, for: indexPath) as! CalendarDateCell
+
         let date = datesWithBlank[indexPath.item]
-        let (current, goal) = stepService.steps(for: date)
-        cell.configure(date: date, currentSteps: current, goalSteps: goal)
+
+        if isStepCountAuthorized {
+            let (current, goal) = stepService.steps(for: date)
+            cell.configure(date: date, currentSteps: current, goalSteps: goal)
+        } else {
+            cell.configure(date: date, currentSteps: nil, goalSteps: nil)
+        }
+
         return cell
     }
 }

--- a/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/StepGoalViewController.swift
@@ -148,9 +148,9 @@ class StepGoalViewController: CoreGradientViewController {
         Task {
             do {
                 try await stepSyncService.syncSteps()
-                print("온보딩 직후 동기화 완료")
+                print("[StepGoalViewController] 온보딩 직후 동기화 완료")
             } catch {
-                print("온보딩 직후 동기화 실패: \(error.localizedDescription)")
+                print("[stepGoalViewController] 온보딩 직후 동기화 실패: \(error.localizedDescription)")
             }
         }
 


### PR DESCRIPTION
## 작업내용
- 캘린더 탭 달력에 "걸음" 연동 상태에 따라 데이터 표시 여부를 결정하도록 했습니다.
- 일부 불필요하다고 생각되는 `print()` 를 제거했습니다.

## 링크
- [노션 태스크](https://www.notion.so/oreumi/258ebaa8982b80bbb736d6e858da78d6?source=copy_link)