### PR TITLE
Fix:맞춤케어 탭 QA 반영

### DIFF
--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -254,7 +254,7 @@
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "개인정보 보호를 위해 생체인증이 필요합니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "걷기 및 활동 데이터를 분석하여 AI가 맞춤 건강 정보를 제공합니다. 일일 걸음 수, 이동 거리, 활동 에너지를 바탕으로 건강 상태를 파악하고 개인화된 추천을 받기 위해 사용자의 건강 데이터 접근이 필요합니다.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "추천코스기능을 위해 위치정보 필요";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "추천 걷기 코스까지의 경로를 안내하기 위해서는 현재 사용자의 위치 정보가 필요합니다. 권한은 언제든지 설정에서 변경할 수 있으며, 사용자의 위치 정보는 경로 안내 목적에만 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -295,7 +295,7 @@
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "개인정보 보호를 위해 생체인증이 필요합니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "걷기 및 활동 데이터를 분석하여 AI가 맞춤 건강 정보를 제공합니다. 일일 걸음 수, 이동 거리, 활동 에너지를 바탕으로 건강 상태를 파악하고 개인화된 추천을 받기 위해 사용자의 건강 데이터 접근이 필요합니다.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "추천코스기능을 위해 위치정보 필요";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "추천 걷기 코스까지의 경로를 안내하기 위해서는 현재 사용자의 위치 정보가 필요합니다. 권한은 언제든지 설정에서 변경할 수 있으며, 사용자의 위치 정보는 경로 안내 목적에만 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/Health/Presentation/Personal/Views/MainView/AISummaryCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/AISummaryCell.xib
@@ -25,8 +25,8 @@
                             <constraint firstAttribute="height" priority="999" constant="127" id="67C-XM-jym"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AI요약" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hEX-sL-gd6">
-                        <rect key="frame" x="5" y="0.0" width="46" height="32"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AI 요약" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hEX-sL-gd6">
+                        <rect key="frame" x="5" y="0.0" width="50" height="32"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>

--- a/Health/Presentation/Personal/Views/MainView/MonthSummaryCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/MonthSummaryCell.xib
@@ -30,26 +30,26 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="hlI-9J-yw7">
                                 <rect key="frame" x="16" y="16" width="415" height="152.66666666666666"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="4W5-YS-PIr">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="4W5-YS-PIr">
                                         <rect key="frame" x="0.0" y="0.0" width="415" height="41"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="총 걸음 수" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUf-6G-6hJ">
-                                                <rect key="frame" x="0.0" y="0.0" width="205" height="41"/>
+                                                <rect key="frame" x="0.0" y="2.3333333333333357" width="205" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YBv-oP-HV2">
-                                                <rect key="frame" x="210" y="0.0" width="205" height="41"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="YBv-oP-HV2">
+                                                <rect key="frame" x="210" y="2.3333333333333357" width="205" height="38.666666666666664"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" text="102332보" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IM2-td-MUR">
-                                                        <rect key="frame" x="0.0" y="0.0" width="205" height="27.666666666666668"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="205" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="지난 달 대비 🔺 520보" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ods-hd-9ii">
-                                                        <rect key="frame" x="0.0" y="27.666666666666661" width="205" height="13.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="205" height="13.333333333333336"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -58,26 +58,26 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0oe-P1-ctD">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="firstBaseline" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0oe-P1-ctD">
                                         <rect key="frame" x="0.0" y="56" width="415" height="40.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="총 거리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agm-Li-mO1">
-                                                <rect key="frame" x="0.0" y="0.0" width="205.66666666666666" height="40.666666666666664"/>
+                                                <rect key="frame" x="0.0" y="2" width="205.66666666666666" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="mSq-am-M1k">
-                                                <rect key="frame" x="209.66666666666663" y="0.0" width="205.33333333333337" height="40.666666666666664"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mSq-am-M1k">
+                                                <rect key="frame" x="209.66666666666663" y="2" width="205.33333333333337" height="38.666666666666664"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="5KM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1bI-zz-HJB">
-                                                        <rect key="frame" x="0.0" y="0.0" width="205.33333333333334" height="27.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="205.33333333333334" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지난 달 대비 🔺 3.5% " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tpz-zX-wrA">
-                                                        <rect key="frame" x="0.0" y="27.333333333333325" width="205.33333333333334" height="13.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="25.333333333333329" width="205.33333333333334" height="13.333333333333336"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -86,26 +86,26 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Nx6-oa-max">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Nx6-oa-max">
                                         <rect key="frame" x="0.0" y="111.66666666666666" width="415" height="41"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="소비 활동 에너지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CzQ-m7-7Nj">
-                                                <rect key="frame" x="0.0" y="0.0" width="205" height="41"/>
+                                                <rect key="frame" x="0.0" y="2.3333333333333428" width="205" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HK0-Vt-uZc">
-                                                <rect key="frame" x="210" y="0.0" width="205" height="41"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="HK0-Vt-uZc">
+                                                <rect key="frame" x="210" y="2.3333333333333428" width="205" height="38.666666666666664"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="100kcal" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HXX-JU-zXY">
-                                                        <rect key="frame" x="0.0" y="0.0" width="205" height="27.666666666666668"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="205" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지난 달 대비 🔺 11.5%" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gh0-e7-X5r">
-                                                        <rect key="frame" x="0.0" y="27.666666666666654" width="205" height="13.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="25.333333333333314" width="205" height="13.333333333333336"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>

--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
@@ -78,10 +78,6 @@ class RecommendPlaceCell: CoreCollectionViewCell {
             return
         }
 
-        // 기본 로딩 상태
-        courseImage.image = UIImage(systemName: "map")
-        courseImage.tintColor = .systemGray3
-
         currentGPXURL = course.gpxpath
         thumbnailTask?.cancel()
 
@@ -96,7 +92,8 @@ class RecommendPlaceCell: CoreCollectionViewCell {
                 courseImage.contentMode = .scaleAspectFill
             } else {
                 courseImage.image = UIImage(systemName: "location.slash")
-                courseImage.tintColor = .systemOrange
+                courseImage.contentMode = .scaleAspectFit
+                courseImage.tintColor = .systemBlue
             }
         }
     }
@@ -107,7 +104,7 @@ class RecommendPlaceCell: CoreCollectionViewCell {
         if distanceText.contains("km") || distanceText.contains("m") {
             userDistanceLabel.textColor = .systemBlue
         } else {
-            userDistanceLabel.textColor = .systemOrange
+            userDistanceLabel.textColor = .systemBlue
         }
     }
 

--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.swift
@@ -62,8 +62,10 @@ class RecommendPlaceCell: CoreCollectionViewCell {
         // 기본 텍스트 설정
         courseNameLabel.text = course.crsKorNm
         locationLabel.text = course.sigun
-        distanceLabel.text = "\(course.crsDstnc)km"
-        durationLabel.text = course.crsTotlRqrmHour.toFormattedDuration()
+        let distance = NSAttributedString(string: "\(course.crsDstnc)km")
+            .font(UIFont.preferredFont(forTextStyle: .footnote), to: "km")
+        distanceLabel.attributedText = distance
+        durationLabel.attributedText = course.crsTotlRqrmHour.toFormattedDuration()
         // 난이도 텍스트와 이미지 색상 동시 설정
         let levelInfo = getLevelInfo(from: course.crsLevel)
         levelLabel.text = levelInfo.text
@@ -151,17 +153,29 @@ class RecommendPlaceCell: CoreCollectionViewCell {
 extension String {
 
     //소요시간 포맷팅
-    func toFormattedDuration() -> String {
+    func toFormattedDuration() -> NSAttributedString {
         let minutes = Int(self)!
         let hours = minutes / 60
         let mins = minutes % 60
 
+        let formattedString: String
+
         if hours > 0 && mins > 0 {
-            return "\(hours)시간 \(mins)분"
+            formattedString = "\(hours)시간 \(mins)분"
         } else if hours > 0 {
-            return "\(hours)시간"
+            formattedString = "\(hours)시간"
         } else {
-            return "\(mins)분"
+            formattedString = "\(mins)분"
         }
+
+        let attributedString = NSAttributedString(string: formattedString)
+
+        // 단위 부분에 footnote 폰트 적용
+        let footnoteFont = UIFont.preferredFont(forTextStyle: .footnote)
+        var result = attributedString
+        result = result.font(footnoteFont, to: "시간")
+        result = result.font(footnoteFont, to: "분")
+
+        return result
     }
 }

--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -21,20 +22,21 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MzM-wC-y0u">
                         <rect key="frame" x="0.0" y="0.0" width="506" height="379"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Coa-gn-qKb">
-                                <rect key="frame" x="0.0" y="0.0" width="506" height="230.66666666666666"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Coa-gn-qKb">
+                                <rect key="frame" x="0.0" y="-2.3333333333333428" width="506" height="235.33333333333331"/>
+                                <imageReference key="image" image="map" catalog="system" symbolScale="large"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="5LA-LE-kKA">
                                 <rect key="frame" x="10" y="240.66666666666663" width="486" height="128.33333333333337"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="abn-0f-PMW">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="-8" translatesAutoresizingMaskIntoConstraints="NO" id="abn-0f-PMW">
                                         <rect key="frame" x="0.0" y="0.0" width="486" height="83"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="1l5-MY-DQq">
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="1l5-MY-DQq">
                                                 <rect key="frame" x="0.0" y="0.0" width="486" height="31"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" text="울산 울주군" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="59X-R2-pzI">
-                                                        <rect key="frame" x="0.0" y="0.0" width="69" height="31"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="69" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" name="buttonTextColor"/>
                                                         <nil key="highlightedColor"/>
@@ -45,13 +47,14 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="4aE-3z-Abs">
                                                                 <rect key="frame" x="10" y="8" width="92" height="15"/>
                                                                 <subviews>
-                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="location.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Juf-Nt-Nwz">
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Juf-Nt-Nwz">
                                                                         <rect key="frame" x="0.0" y="0.99999999999999822" width="15" height="13.333333333333336"/>
                                                                         <color key="tintColor" systemColor="linkColor"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="15" id="bkF-hH-61f"/>
                                                                             <constraint firstAttribute="height" constant="15" id="kXs-av-Y48"/>
                                                                         </constraints>
+                                                                        <imageReference key="image" image="location.fill" catalog="system" symbolScale="medium"/>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="위치 권한 없음." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wwe-T6-htg">
                                                                         <rect key="frame" x="20" y="0.0" width="72" height="15"/>
@@ -62,7 +65,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                         </subviews>
-                                                        <color key="backgroundColor" name="toastStrokeColor"/>
+                                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                         <constraints>
                                                             <constraint firstItem="4aE-3z-Abs" firstAttribute="top" secondItem="ner-ws-p0x" secondAttribute="top" constant="8" id="3io-Hn-fKL"/>
                                                             <constraint firstAttribute="bottom" secondItem="4aE-3z-Abs" secondAttribute="bottom" constant="8" id="O2e-jI-TIL"/>
@@ -78,7 +81,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="해파랑길 2ㅇㅇㅇㅇㅇ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d6n-jr-5VV">
-                                                <rect key="frame" x="0.0" y="31.000000000000028" width="147" height="52"/>
+                                                <rect key="frame" x="0.0" y="23.000000000000028" width="147" height="60"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -91,23 +94,24 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="9ar-hd-o0N">
-                                        <rect key="frame" x="0.0" y="108.00000000000003" width="308" height="20.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="108.00000000000003" width="297.33333333333331" height="20.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="sAy-tJ-T4h">
-                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="103.66666666666667" height="20.333333333333332"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="figure.walk" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4Cd-Z9-pi7">
-                                                        <rect key="frame" x="0.0" y="-0.3333333333333357" width="16" height="21.666666666666668"/>
-                                                        <color key="tintColor" systemColor="systemBlueColor"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4Cd-Z9-pi7">
+                                                        <rect key="frame" x="0.0" y="1.6666666666666661" width="13" height="17.666666666666664"/>
+                                                        <color key="tintColor" name="AccentColor"/>
+                                                        <imageReference key="image" image="figure.walk" catalog="system" symbolScale="small"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="총 거리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MoV-r4-zU4">
-                                                        <rect key="frame" x="21" y="0.0" width="43" height="20.333333333333332"/>
+                                                        <rect key="frame" x="18" y="0.0" width="43" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="17Km" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vqH-Y3-HTf">
-                                                        <rect key="frame" x="69" y="0.0" width="37.666666666666657" height="20.333333333333332"/>
+                                                        <rect key="frame" x="66" y="0.0" width="37.666666666666657" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                                         <nil key="highlightedColor"/>
@@ -115,20 +119,21 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="wA5-E3-93B">
-                                                <rect key="frame" x="121.66666666666666" y="0.0" width="112.33333333333334" height="20.333333333333332"/>
+                                                <rect key="frame" x="118.66666666666666" y="0.0" width="108.33333333333334" height="20.333333333333332"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="timer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="GOn-Hu-pJh">
-                                                        <rect key="frame" x="0.0" y="0.66666666666666607" width="19.666666666666668" height="19"/>
-                                                        <color key="tintColor" systemColor="systemBlueColor"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GOn-Hu-pJh">
+                                                        <rect key="frame" x="0.0" y="2.3333333333333313" width="15.666666666666666" height="15.666666666666668"/>
+                                                        <color key="tintColor" name="AccentColor"/>
+                                                        <imageReference key="image" image="timer" catalog="system" symbolScale="small"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="약" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GA9-Nf-8i2">
-                                                        <rect key="frame" x="24.666666666666686" y="0.0" width="13" height="20.333333333333332"/>
+                                                        <rect key="frame" x="20.666666666666686" y="0.0" width="13" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="7시간 30분" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K1g-4l-9EY">
-                                                        <rect key="frame" x="42.666666666666693" y="0.0" width="69.666666666666686" height="20.333333333333332"/>
+                                                        <rect key="frame" x="38.666666666666693" y="0.0" width="69.666666666666686" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                                         <nil key="highlightedColor"/>
@@ -136,14 +141,15 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Kpw-uE-Rp4">
-                                                <rect key="frame" x="249" y="0.0" width="59" height="20.333333333333332"/>
+                                                <rect key="frame" x="242.00000000000003" y="0.0" width="55.333333333333343" height="20.333333333333332"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flame.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="9gA-Ma-LIY">
-                                                        <rect key="frame" x="0.0" y="-0.33333333333333215" width="16.666666666666668" height="19.999999999999996"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9gA-Ma-LIY">
+                                                        <rect key="frame" x="0.0" y="1.6666666666666643" width="13" height="16.333333333333336"/>
                                                         <color key="tintColor" name="warningSymbolColor"/>
+                                                        <imageReference key="image" image="flame.fill" catalog="system" symbolScale="small"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aR8-eQ-5SL">
-                                                        <rect key="frame" x="21.666666666666689" y="0.0" width="37.333333333333343" height="20.333333333333332"/>
+                                                        <rect key="frame" x="18.000000000000004" y="0.0" width="37.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                                         <nil key="highlightedColor"/>
@@ -221,15 +227,16 @@
         <image name="figure.walk" catalog="system" width="94" height="128"/>
         <image name="flame.fill" catalog="system" width="106" height="128"/>
         <image name="location.fill" catalog="system" width="128" height="119"/>
+        <image name="map" catalog="system" width="128" height="112"/>
         <image name="timer" catalog="system" width="128" height="123"/>
+        <namedColor name="AccentColor">
+            <color red="1" green="0.79199999570846558" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="boxBgColor">
             <color red="0.95294117647058818" green="0.95294117647058818" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="buttonTextColor">
             <color red="0.41568627450980394" green="0.41568627450980394" blue="0.41568627450980394" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-        </namedColor>
-        <namedColor name="toastStrokeColor">
-            <color red="0.90588235294117647" green="0.90588235294117647" blue="0.90588235294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="warningSymbolColor">
             <color red="1" green="0.55686274509803924" blue="0.14117647058823529" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -240,8 +247,8 @@
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/RecommendPlaceCell.xib
@@ -230,7 +230,7 @@
         <image name="map" catalog="system" width="128" height="112"/>
         <image name="timer" catalog="system" width="128" height="123"/>
         <namedColor name="AccentColor">
-            <color red="1" green="0.79199999570846558" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.7803921568627451" blue="0.74117647058823533" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="boxBgColor">
             <color red="0.95294117647058818" green="0.95294117647058818" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Health/Presentation/Personal/Views/MainView/WalkingFilterCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/WalkingFilterCell.xib
@@ -19,22 +19,25 @@
                 <rect key="frame" x="0.0" y="0.0" width="402" height="43"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="160" translatesAutoresizingMaskIntoConstraints="NO" id="VIi-bO-Yfu">
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="firstBaseline" spacing="160" translatesAutoresizingMaskIntoConstraints="NO" id="VIi-bO-Yfu">
                         <rect key="frame" x="0.0" y="0.0" width="402" height="43"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="추천 걷기 코스" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i7a-7B-Uef">
-                                <rect key="frame" x="0.0" y="0.0" width="96.666666666666671" height="43"/>
+                                <rect key="frame" x="0.0" y="15.999999999999998" width="96.666666666666671" height="20.333333333333329"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" showsMenuAsPrimaryAction="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gaj-bz-YeX">
-                                <rect key="frame" x="302" y="0.0" width="100" height="43"/>
+                                <rect key="frame" x="302" y="13" width="100" height="30"/>
                                 <color key="backgroundColor" name="boxBgColor"/>
                                 <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="flh-fp-RZC"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="gYN-0z-3Md"/>
                                     <constraint firstAttribute="width" constant="100" id="nA1-eg-4mV"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                <color key="tintColor" systemColor="linkColor"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <menu key="menu" id="Xqt-q9-rX4">
                                     <children>
@@ -71,6 +74,9 @@
         </namedColor>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Health/Presentation/Personal/Views/MainView/WalkingHeaderCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/WalkingHeaderCell.swift
@@ -13,5 +13,4 @@ class WalkingHeaderCell: UICollectionViewCell {
         super.awakeFromNib()
         // Initialization code
     }
-
 }

--- a/Health/Presentation/Personal/Views/MainView/WeekSummaryCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/WeekSummaryCell.swift
@@ -83,14 +83,14 @@ class WeekSummaryCell: CoreCollectionViewCell {
 
     private func updateUIWithData(_ data: WeeklyHealthData) {
         // 걸음수 스타일링
-        let stepsString = "\(data.weeklyTotalSteps.formatted()) 걸음"
+        let stepsString = "\(data.weeklyTotalSteps.formatted())걸음"
         let stepsAttrString = NSAttributedString(string: stepsString)
             .font(.preferredFont(forTextStyle: .footnote), to: "걸음")
             .foregroundColor(.secondaryLabel, to: "걸음")
         walkingLabel.attributedText = stepsAttrString
 
         // 거리 스타일링
-        let distanceString = "\(String(format: "%.1f", data.weeklyTotalDistance)) km"
+        let distanceString = "\(String(format: "%.1f", data.weeklyTotalDistance))km"
         let distanceAttrString = NSAttributedString(string: distanceString)
             .font(.preferredFont(forTextStyle: .footnote), to: "km")
             .foregroundColor(.secondaryLabel, to: "km")

--- a/Health/Presentation/Personal/Views/MainView/WeekSummaryCell.xib
+++ b/Health/Presentation/Personal/Views/MainView/WeekSummaryCell.xib
@@ -18,8 +18,8 @@
                 <rect key="frame" x="0.0" y="0.0" width="357" height="285"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이번주 기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zIx-qZ-V2K">
-                        <rect key="frame" x="5" y="0.0" width="77.666666666666671" height="18.333333333333332"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이번 주 기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zIx-qZ-V2K">
+                        <rect key="frame" x="5" y="0.0" width="82" height="18.333333333333332"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>
@@ -132,7 +132,7 @@
             <color red="0.95294117647058818" green="0.95294117647058818" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
@@ -38,7 +38,7 @@ final class CourseInfoView: UIView {
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16)
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 

--- a/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
@@ -38,7 +38,7 @@ final class CourseInfoView: UIView {
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
         ])
     }
 


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- SF심볼 사이즈 축소
- 거리측정중..이나 위치권한 없음 시 Label 색상 주황색 -> 파란색으로 수정
- 여백 및 높이 수정
- 시간과 km의 단위 Label은 더 작게 표시

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
<img width="382" height="832" alt="IMG_7136" src="https://github.com/user-attachments/assets/cbf7a766-0140-4695-9988-57444e61af8d" />
<img width="382" height="832" alt="IMG_7133" src="https://github.com/user-attachments/assets/8e510c69-4f99-4bcd-8932-286cc6d5b59d" />
<img width="382" height="832" alt="IMG_7135" src="https://github.com/user-attachments/assets/0be4aa1a-ecc7-4b9f-b034-ef4ef93ee924" />
<img width="382" height="832" alt="IMG_7134" src="https://github.com/user-attachments/assets/76694872-ba0b-4241-a854-1d84e8da9c86" />

| :-:| :-: |
|    |     |

---

### 💜 결과

-
