### PR TITLE
test: CalendarViewModel 테스트 코드 추가

### DIFF
--- a/HealthTests/ViewModels/CalendarViewModelTests.swift
+++ b/HealthTests/ViewModels/CalendarViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Health
+
+@MainActor
+final class CalendarViewModelTests: XCTestCase {
+
+    private var sut: CalendarViewModel!
+
+    override func setUp() {
+        super.setUp()
+        sut = CalendarViewModel()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+
+    func testInit_WhenCreated_ThenContainsFiveYearsOfMonths() {
+        // given
+        let expectedYears = 5 // 현재 연도 ±2년
+        let monthsPerYear = 12
+
+        // then
+        XCTAssertEqual(sut.monthsCount, expectedYears * monthsPerYear)
+    }
+
+    func testMonthAt_WhenIndexIsInvalid_ThenReturnNil() {
+        // then
+        XCTAssertNil(sut.month(at: -1))
+        XCTAssertNil(sut.month(at: sut.monthsCount))
+    }
+
+    func testMonthAt_WhenIndexIsValid_ThenReturnMonthData() {
+        // when
+        let month = sut.month(at: 0)
+
+        // then
+        XCTAssertNotNil(month)
+        XCTAssertTrue((1...12).contains(month?.month ?? 0))
+        XCTAssertNotNil(month?.year)
+    }
+
+    func testIndexOfCurrentMonth_WhenCalled_ThenReturnValidIndexPath() {
+        // when
+        let indexPath = sut.indexOfCurrentMonth()
+
+        // then
+        XCTAssertNotNil(indexPath)
+        XCTAssertTrue((0..<sut.monthsCount).contains(indexPath?.item ?? -1))
+    }
+
+    func testLoadMoreTop_WhenCalled_ThenInsertsMonthsAtBeginning() async {
+        // given
+        let initialCount = sut.monthsCount
+
+        // when
+        await sut.loadMoreTop()
+
+        // then
+        XCTAssertTrue(sut.monthsCount > initialCount)
+        XCTAssertEqual(sut.month(at: 0)?.month, 1) // 항상 1월부터 시작
+    }
+
+    func testLoadMoreBottom_WhenCalled_ThenAppendsMonthsAtEnd() async {
+        // given
+        let initialCount = sut.monthsCount
+
+        // when
+        await sut.loadMoreBottom()
+
+        // then
+        XCTAssertTrue(sut.monthsCount > initialCount)
+    }
+}


### PR DESCRIPTION
## 작업내용
- CalendarViewModel에 대한 테스트 코드를 추가했습니다.

## 테스트
| DEBUG - 아이폰 | DEBUG - 아이패드 |
| -- | -- |
| <img width="530" height="199" alt="image" src="https://github.com/user-attachments/assets/0b66299d-0bf8-4585-b4f1-7bd7885be4d2" /> | <img width="533" height="199" alt="image" src="https://github.com/user-attachments/assets/8557ddfe-ee3e-47cc-a66b-ed8734ddb7c2" /> |

## 링크

- [노션 태스크](https://www.notion.so/oreumi/CalendarViewModel-25bebaa8982b809ca731dd4e23968182?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)