### PR TITLE
Feat/chatbot bug fix: 챗봇 맞춤 토스터블 메시지 위치 수정, 위젯 관련 빌드 세팅 수정, 챗봇 채팅창 UI 수정

### DIFF
--- a/Health.xcodeproj/project.pbxproj
+++ b/Health.xcodeproj/project.pbxproj
@@ -371,7 +371,7 @@
 				CODE_SIGN_ENTITLEMENTS = Health/Health.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "개인정보 보호를 위해 생체인증이 필요합니다.";
@@ -412,7 +412,7 @@
 				CODE_SIGN_ENTITLEMENTS = Health/Health.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Health/Resources/Info.plist;
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "개인정보 보호를 위해 생체인증이 필요합니다.";
@@ -575,7 +575,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
@@ -596,7 +596,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
@@ -618,23 +618,23 @@
 				CODE_SIGN_ENTITLEMENTS = HealthWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthWidget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunwoo.walking.HealthWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(WIDGET_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WIDGET_BUNDLE_IDENTIFIER = "$(WIDGET_BUNDLE_IDENTIFIER)";
 			};
 			name = Debug;
 		};
@@ -647,23 +647,23 @@
 				CODE_SIGN_ENTITLEMENTS = HealthWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4DQM269FVB;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthWidget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunwoo.walking.HealthWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(WIDGET_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WIDGET_BUNDLE_IDENTIFIER = "$(WIDGET_BUNDLE_IDENTIFIER)";
 			};
 			name = Release;
 		};

--- a/Health/Core/Protocols/ToastType.swift
+++ b/Health/Core/Protocols/ToastType.swift
@@ -1,0 +1,39 @@
+//
+//  ToastType.swift
+//  Health
+//
+//  Created by Seohyun Kim on 8/26/25.
+//
+
+import Foundation
+import UIKit
+
+enum ToastType {
+	case warning
+	case success
+	case info
+
+	var iconName: String {
+		switch self {
+		case .warning: return "exclamationmark.triangle.fill"
+		case .success: return "checkmark.circle.fill"
+		case .info:    return "info.circle.fill"
+		}
+	}
+
+	var backgroundColor: UIColor {
+		switch self {
+		case .warning: return UIColor.systemOrange.withAlphaComponent(0.9)
+		case .success: return UIColor.systemGreen.withAlphaComponent(0.9)
+		case .info:    return UIColor.systemBlue.withAlphaComponent(0.9)
+		}
+	}
+
+	var tintColor: UIColor {
+		switch self {
+		case .warning: return .white
+		case .success: return .white
+		case .info:    return .white
+		}
+	}
+}

--- a/Health/Core/Protocols/Toastable.swift
+++ b/Health/Core/Protocols/Toastable.swift
@@ -22,130 +22,316 @@ extension UIViewController: Toastable {}
 
 @MainActor
 extension Toastable where Self: UIViewController {
-    /// 화면 하단에 캡슐 형태의 토스트 메시지를 띄웁니다.
-    /// - Parameters:
-    ///   - message: 표시할 문자열
-    ///   - duration: 토스트가 완전히 보이는 시간(초) (기본값 2.0초)
-    func showToast(message: String, duration: TimeInterval = 2.0) {
-        let toastContainer = UIView()
-        toastContainer.alpha = 0
-        toastContainer.clipsToBounds = true
-        
-        let toastLabel = UILabel()
-        toastLabel.textAlignment = .center
-        toastLabel.font = .systemFont(ofSize: 14)
-        toastLabel.text = message
-        toastLabel.numberOfLines = 0
-        
-        let isLight = traitCollection.userInterfaceStyle == .light
-        let backgroundColor = (isLight ? UIColor.black : UIColor.white).withAlphaComponent(0.9)
-        toastContainer.backgroundColor = backgroundColor
-        toastLabel.textColor = isLight ? .white : .black
-        
-        toastContainer.addSubview(toastLabel)
-        view.addSubview(toastContainer)
-        
-        toastContainer.translatesAutoresizingMaskIntoConstraints = false
-        toastLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            toastLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 12),
-            toastLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -12),
-            toastLabel.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: 8),
-            toastLabel.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -8),
-            
-            toastContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            toastContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            toastContainer.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
-            toastContainer.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
-        ])
-        
-        view.layoutIfNeeded()
-        toastContainer.layer.cornerRadius = toastContainer.bounds.height / 2
-        
-        UIView.animate(withDuration: 0.5, animations: {
-            toastContainer.alpha = 1
-        }) { _ in
-            UIView.animate(
-                withDuration: 0.5,
-                delay: duration,
-                options: .curveEaseOut,
-                animations: { toastContainer.alpha = 0 },
-                completion: { _ in toastContainer.removeFromSuperview() }
-            )
-        }
-    }
-    
-    func showWarningToast(title: String, message: String, duration: TimeInterval = 2.0) {
-        let toastContainer = UIView()
-        toastContainer.alpha = 0
-        toastContainer.clipsToBounds = true
-        toastContainer.layer.cornerRadius = 12
-        
-        toastContainer.backgroundColor = .toastWarningBg
-        
-        let iconView = UIImageView()
-        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
-        iconView.image = UIImage(systemName: "exclamationmark.triangle.fill", withConfiguration: config)
-        iconView.tintColor = .warningSymbol
-        
-        iconView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            iconView.widthAnchor.constraint(equalToConstant: 24),
-            iconView.heightAnchor.constraint(equalToConstant: 24)
-        ])
+	/// 화면 하단에 캡슐 형태의 토스트 메시지를 띄웁니다.
+	/// - Parameters:
+	///   - message: 표시할 문자열
+	///   - duration: 토스트가 완전히 보이는 시간(초) (기본값 2.0초)
+	func showToast(message: String, duration: TimeInterval = 2.0) {
+		let toastContainer = UIView()
+		toastContainer.alpha = 0
+		toastContainer.clipsToBounds = true
+		
+		let toastLabel = UILabel()
+		toastLabel.textAlignment = .center
+		toastLabel.font = .systemFont(ofSize: 14)
+		toastLabel.text = message
+		toastLabel.numberOfLines = 0
+		
+		let isLight = traitCollection.userInterfaceStyle == .light
+		let backgroundColor = (isLight ? UIColor.black : UIColor.white).withAlphaComponent(0.9)
+		toastContainer.backgroundColor = backgroundColor
+		toastLabel.textColor = isLight ? .white : .black
+		
+		toastContainer.addSubview(toastLabel)
+		view.addSubview(toastContainer)
+		
+		toastContainer.translatesAutoresizingMaskIntoConstraints = false
+		toastLabel.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate([
+			toastLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 12),
+			toastLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -12),
+			toastLabel.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: 8),
+			toastLabel.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -8),
+			
+			toastContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+			toastContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
+			toastContainer.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
+			toastContainer.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
+		])
+		
+		view.layoutIfNeeded()
+		toastContainer.layer.cornerRadius = toastContainer.bounds.height / 2
+		
+		UIView.animate(withDuration: 0.5, animations: {
+			toastContainer.alpha = 1
+		}) { _ in
+			UIView.animate(
+				withDuration: 0.5,
+				delay: duration,
+				options: .curveEaseOut,
+				animations: { toastContainer.alpha = 0 },
+				completion: { _ in toastContainer.removeFromSuperview() }
+			)
+		}
+	}
+	
+	func showWarningToast(title: String, message: String, duration: TimeInterval = 2.0) {
+		let toastContainer = UIView()
+		toastContainer.alpha = 0
+		toastContainer.clipsToBounds = true
+		toastContainer.layer.cornerRadius = 12
+		
+		toastContainer.backgroundColor = .toastWarningBg
+		
+		let iconView = UIImageView()
+		let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+		iconView.image = UIImage(systemName: "exclamationmark.triangle.fill", withConfiguration: config)
+		iconView.tintColor = .warningSymbol
+		
+		let titleLabel = UILabel()
+		titleLabel.text = title
+		titleLabel.font = .boldSystemFont(ofSize: 16)
+		titleLabel.textColor = .label
+		titleLabel.numberOfLines = 0
+		
+		let messageLabel = UILabel()
+		messageLabel.text = message
+		messageLabel.font = .systemFont(ofSize: 14)
+		messageLabel.textColor = .secondaryLabel
+		messageLabel.numberOfLines = 0
+		
+		let textStack = UIStackView(arrangedSubviews: [titleLabel, messageLabel])
+		textStack.axis = .vertical
+		textStack.spacing = 4
+		
+		let contentStack = UIStackView(arrangedSubviews: [iconView, textStack])
+		contentStack.axis = .horizontal
+		contentStack.alignment = .center
+		contentStack.spacing = 8
+		
+		toastContainer.addSubview(contentStack)
+		view.addSubview(toastContainer)
+		
+		toastContainer.translatesAutoresizingMaskIntoConstraints = false
+		contentStack.translatesAutoresizingMaskIntoConstraints = false
+		
+		NSLayoutConstraint.activate([
+			contentStack.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 12),
+			contentStack.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -12),
+			contentStack.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: 12),
+			contentStack.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -12),
+			
+			toastContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+			toastContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
+			toastContainer.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
+			toastContainer.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
+		])
+		
+		UIView.animate(withDuration: 0.5, animations: {
+			toastContainer.alpha = 1
+		}) { _ in
+			UIView.animate(
+				withDuration: 0.5,
+				delay: duration,
+				options: .curveEaseOut,
+				animations: { toastContainer.alpha = 0 },
+				completion: { _ in toastContainer.removeFromSuperview() }
+			)
+		}
+	}
+	
+	func showToastAboveKeyboard(
+		type: ToastType,
+		title: String,
+		message: String,
+		duration: TimeInterval = 2.0,
+		keyboardHeight: CGFloat = 0
+	) {
+		guard let keyWindow = getKeyWindow() else { return }
 
-        let titleLabel = UILabel()
-        titleLabel.text = title
-        titleLabel.font = .boldSystemFont(ofSize: 16)
-        titleLabel.textColor = .label
-        titleLabel.numberOfLines = 0
-        titleLabel.textAlignment = .center
-        
-        let messageLabel = UILabel()
-        messageLabel.text = message
-        messageLabel.font = .systemFont(ofSize: 14)
-        messageLabel.textColor = .secondaryLabel
-        messageLabel.numberOfLines = 0
-        messageLabel.textAlignment = .center
-        
-        let textStack = UIStackView(arrangedSubviews: [titleLabel, messageLabel])
-        textStack.axis = .vertical
-        textStack.spacing = 4
-        
-        let contentStack = UIStackView(arrangedSubviews: [iconView, textStack])
-        contentStack.axis = .horizontal
-        contentStack.alignment = .center
-        contentStack.spacing = 8
-        
-        toastContainer.addSubview(contentStack)
-        view.addSubview(toastContainer)
-        
-        toastContainer.translatesAutoresizingMaskIntoConstraints = false
-        contentStack.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            contentStack.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: 12),
-            contentStack.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -12),
-            contentStack.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: 12),
-            contentStack.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -12),
-            
-            toastContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            toastContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -40),
-            toastContainer.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7)
-        ])
-        
-        UIView.animate(withDuration: 0.5, animations: {
-            toastContainer.alpha = 1
-        }) { _ in
-            UIView.animate(
-                withDuration: 0.5,
-                delay: duration,
-                options: .curveEaseOut,
-                animations: { toastContainer.alpha = 0 },
-                completion: { _ in toastContainer.removeFromSuperview() }
-            )
-        }
-    }
-    
-    
+		let toastView = buildToastView(type: type, title: title, message: message)
+		keyWindow.addSubview(toastView)
+		toastView.translatesAutoresizingMaskIntoConstraints = false
+
+		let constraints = makePlatformToastConstraints(
+			for: toastView,
+			in: keyWindow,
+			keyboardHeight: keyboardHeight
+		)
+
+		NSLayoutConstraint.activate(constraints)
+		animateToast(view: toastView, duration: duration)
+	}
+
+	/// 현재 앱의 키 윈도우를 반환
+	/// - Returns: keyWindow, 없을 경우 nil
+	private func getKeyWindow() -> UIWindow? {
+		UIApplication.shared.connectedScenes
+			.compactMap { $0 as? UIWindowScene }
+			.flatMap { $0.windows }
+			.first(where: { $0.isKeyWindow })
+	}
+	/// 키보드 상태에 따라 토스트의 하단 오프셋 값을 계산
+	/// - Parameters:
+	///   - window: 기준 윈도우
+	///   - keyboardHeight: 현재 키보드 높이
+	/// - Returns: 키보드 또는 기본 값에 따른 하단 offset
+	private func calculateToastBottomOffset(
+		for window: UIWindow,
+		keyboardHeight: CGFloat
+	) -> CGFloat {
+		let safeBottomInset = window.safeAreaInsets.bottom
+
+		// iPad는 키보드가 커서 더 큰 offset 필요
+		let defaultOffset: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 200 : 100
+
+		let finalOffset = keyboardHeight > 0
+			? (keyboardHeight + 8)
+			: (safeBottomInset + defaultOffset)
+
+		return finalOffset
+	}
+	/// 기본적인 하단 중심 기준의 토스트 제약을 생성
+	/// - Parameters:
+	///   - toastView: 토스트 뷰
+	///   - window: 기준 윈도우
+	///   - bottomOffset: 하단 offset
+	/// - Returns: NSLayoutConstraint 배열
+	private func makeToastConstraints(
+		for toastView: UIView,
+		in window: UIWindow,
+		bottomOffset: CGFloat
+	) -> [NSLayoutConstraint] {
+		var constraints: [NSLayoutConstraint] = [
+			toastView.bottomAnchor.constraint(equalTo: window.bottomAnchor, constant: -bottomOffset)
+		]
+
+		constraints += horizontalConstraints(for: toastView, in: window)
+		return constraints
+	}
+	/// 디바이스에 따라 토스트의 수평 제약을 설정
+	/// - Parameters:
+	///   - toastView: 토스트 뷰
+	///   - window: 기준 윈도우
+	/// - Returns: NSLayoutConstraint 배열
+	private func horizontalConstraints(
+		for toastView: UIView,
+		in window: UIWindow
+	) -> [NSLayoutConstraint] {
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			return [
+				toastView.centerXAnchor.constraint(equalTo: window.centerXAnchor),
+				toastView.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
+				toastView.leadingAnchor.constraint(greaterThanOrEqualTo: window.leadingAnchor, constant: 16),
+				toastView.trailingAnchor.constraint(lessThanOrEqualTo: window.trailingAnchor, constant: -16)
+			]
+		} else {
+			return [
+				toastView.leadingAnchor.constraint(equalTo: window.leadingAnchor, constant: 16),
+				toastView.trailingAnchor.constraint(equalTo: window.trailingAnchor, constant: -16)
+			]
+		}
+	}
+	/// 플랫폼(디바이스) 특성을 고려하여 토스트의 위치 제약을 생성
+	/// - Parameters:
+	///   - toastView: 토스트 뷰
+	///   - window: 기준 윈도우
+	///   - keyboardHeight: 키보드 높이
+	/// - Returns: NSLayoutConstraint 배열
+	private func makePlatformToastConstraints(
+		for toastView: UIView,
+		in window: UIWindow,
+		keyboardHeight: CGFloat
+	) -> [NSLayoutConstraint] {
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			let topInset = window.safeAreaInsets.top
+			return [
+				toastView.topAnchor.constraint(equalTo: window.topAnchor, constant: topInset + 32)
+			] + horizontalConstraints(for: toastView, in: window)
+		} else {
+			let bottomOffset = calculateToastBottomOffset(for: window, keyboardHeight: keyboardHeight)
+			return makeToastConstraints(for: toastView, in: window, bottomOffset: bottomOffset)
+		}
+	}
+	/// 토스트 UI를 구성하여 반환
+	/// - Parameters:
+	///   - type: 토스트 타입 (성공, 경고 등)
+	///   - title: 제목 텍스트
+	///   - message: 본문 메시지
+	/// - Returns: 완성된 토스트 UIView
+	private func buildToastView(type: ToastType, title: String, message: String) -> UIView {
+		let container = UIView()
+		   container.backgroundColor = type.backgroundColor
+		   container.layer.cornerRadius = 12
+		   container.clipsToBounds = true
+		   container.alpha = 0
+
+		   let iconView = UIImageView()
+		   let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+		   iconView.image = UIImage(systemName: type.iconName, withConfiguration: config)
+		   iconView.tintColor = type.tintColor
+
+		   iconView.setContentHuggingPriority(.required, for: .horizontal)
+		   iconView.setContentCompressionResistancePriority(.required, for: .horizontal)
+		   iconView.translatesAutoresizingMaskIntoConstraints = false
+		   iconView.widthAnchor.constraint(equalToConstant: 20).isActive = true
+		   iconView.heightAnchor.constraint(equalToConstant: 20).isActive = true
+
+		   let titleLabel = UILabel()
+		   titleLabel.text = title
+		   titleLabel.font = .boldSystemFont(ofSize: 16)
+		   titleLabel.textColor = .white
+		   titleLabel.numberOfLines = 0
+		   titleLabel.textAlignment = .center
+
+		   let messageLabel = UILabel()
+		   messageLabel.text = message
+		   messageLabel.font = .systemFont(ofSize: 14)
+		   messageLabel.textColor = .white.withAlphaComponent(0.8)
+		   messageLabel.numberOfLines = 0
+		   messageLabel.textAlignment = .center
+
+		   let titleStack = UIStackView(arrangedSubviews: [iconView, titleLabel])
+		   titleStack.axis = .horizontal
+		   titleStack.alignment = .center
+		   titleStack.spacing = 8
+
+		   let verticalStack = UIStackView(arrangedSubviews: [titleStack, messageLabel])
+		   verticalStack.axis = .vertical
+		   verticalStack.alignment = .center
+		   verticalStack.spacing = 4
+
+		   container.addSubview(verticalStack)
+		   verticalStack.translatesAutoresizingMaskIntoConstraints = false
+
+		   NSLayoutConstraint.activate([
+			   verticalStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+			   verticalStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+			   verticalStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+			   verticalStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12)
+		   ])
+
+		   return container
+	}
+	/// 토스트를 페이드 인/아웃 애니메이션과 함께 보여줍니다.
+	/// - Parameters:
+	///   - view: 토스트 뷰
+	///   - duration: 보여지는 시간
+	private func animateToast(view: UIView, duration: TimeInterval) {
+		UIView.animate(withDuration: 0.3, animations: {
+			view.alpha = 1
+		}) { _ in
+			UIView.animate(
+				withDuration: 0.3,
+				delay: duration,
+				options: .curveEaseOut,
+				animations: {
+					view.alpha = 0
+				},
+				completion: { _ in
+					view.removeFromSuperview()
+				}
+			)
+		}
+	}
 }

--- a/Health/Core/Shared/SharedStore.swift
+++ b/Health/Core/Shared/SharedStore.swift
@@ -10,7 +10,7 @@ import Foundation
 enum SharedStore {
 	// NOTE: - 반드시 suiteID에 본인의 group.com.myWidgetSuiteName.walking으로 바꿔주세요.
 	// 앱그룹의 번들 아이디는 중복이 되면 아예 빌드가 안되는 문제도 있습니다.
-    static let suiteID = "group.com.kunwoo.walking"
+    static let suiteID = "group.com.seohyun2.walking"
 
 	private static var ud: UserDefaults {
 		guard let u = UserDefaults(suiteName: suiteID) else {

--- a/Health/Presentation/Chatbot/Chatbot.storyboard
+++ b/Health/Presentation/Chatbot/Chatbot.storyboard
@@ -27,44 +27,46 @@
                                 </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3mU-rj-JGX">
-                                <rect key="frame" x="16" y="706.33333333333337" width="361" height="77.666666666666629"/>
+                                <rect key="frame" x="0.0" y="706.33333333333337" width="393" height="77.666666666666629"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JcR-5o-DiP">
-                                        <rect key="frame" x="0.0" y="0.0" width="361" height="54"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="UtS-cd-zXs" userLabel="ChattingInputContainer">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="77.666666666666671"/>
                                         <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="    걸어봇에게 물어보세요." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o50-vy-lbP">
-                                                <rect key="frame" x="0.0" y="0.0" width="305" height="54"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                            </textField>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jhw-LG-ZoI">
-                                                <rect key="frame" x="313" y="0.0" width="48" height="54"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="48" id="hjq-4q-gJk"/>
-                                                    <constraint firstAttribute="height" constant="54" id="tHv-qc-zKU"/>
-                                                </constraints>
-                                                <color key="tintColor" systemColor="labelColor"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" image="paperplane.fill" catalog="system">
-                                                    <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="20"/>
-                                                </buttonConfiguration>
-                                                <connections>
-                                                    <action selector="sendButtonTapped:" destination="yZA-Tc-F2L" eventType="touchUpInside" id="xSl-Ua-B6q"/>
-                                                </connections>
-                                            </button>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JcR-5o-DiP">
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="54"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="    걸어봇에게 물어보세요." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o50-vy-lbP">
+                                                        <rect key="frame" x="0.0" y="0.0" width="337" height="54"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                    </textField>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jhw-LG-ZoI">
+                                                        <rect key="frame" x="345" y="0.0" width="48" height="54"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="48" id="hjq-4q-gJk"/>
+                                                            <constraint firstAttribute="height" constant="54" id="tHv-qc-zKU"/>
+                                                        </constraints>
+                                                        <color key="tintColor" systemColor="labelColor"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" image="paperplane.fill" catalog="system">
+                                                            <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="20"/>
+                                                        </buttonConfiguration>
+                                                        <connections>
+                                                            <action selector="sendButtonTapped:" destination="yZA-Tc-F2L" eventType="touchUpInside" id="xSl-Ua-B6q"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" name="boxBgColor"/>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alan AI는 정보 제공시 실수를 할 수 있으니 다시 한번 확인하세요." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Dn-0Q-cLi">
+                                                <rect key="frame" x="0.0" y="61.999999999999993" width="393" height="15.666666666666664"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <color key="textColor" name="buttonTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
-                                        <color key="backgroundColor" name="boxBgColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="54" id="Xy2-pH-nEn"/>
-                                        </constraints>
                                     </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alan AI는 정보 제공시 실수를 할 수 있으니 다시 한번 확인하세요." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Dn-0Q-cLi">
-                                        <rect key="frame" x="0.0" y="61.999999999999993" width="361" height="15.666666666666664"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <color key="textColor" name="buttonTextColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </stackView>
@@ -86,16 +88,18 @@
                             <constraint firstItem="vgf-3o-Tx2" firstAttribute="bottom" secondItem="Sjn-mm-DvB" secondAttribute="bottom" constant="80" id="RqY-8N-hsN"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="top" secondItem="pb1-hy-Jgy" secondAttribute="bottom" id="Zlc-r2-1AD"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" id="ioe-9z-joi"/>
-                            <constraint firstItem="vgf-3o-Tx2" firstAttribute="trailing" secondItem="3mU-rj-JGX" secondAttribute="trailing" constant="16" id="kHh-e7-Smv"/>
-                            <constraint firstItem="3mU-rj-JGX" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" constant="16" id="oL1-rU-rTT"/>
+                            <constraint firstItem="vgf-3o-Tx2" firstAttribute="trailing" secondItem="3mU-rj-JGX" secondAttribute="trailing" id="kHh-e7-Smv"/>
+                            <constraint firstItem="3mU-rj-JGX" firstAttribute="leading" secondItem="vgf-3o-Tx2" secondAttribute="leading" id="oL1-rU-rTT"/>
                             <constraint firstItem="Sjn-mm-DvB" firstAttribute="trailing" secondItem="vgf-3o-Tx2" secondAttribute="trailing" id="zec-a9-W3H"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="chattingContainerStackView" destination="3mU-rj-JGX" id="kTS-Vf-4iy"/>
+                        <outlet property="chattingInputContainer" destination="UtS-cd-zXs" id="nKH-Av-NLN"/>
                         <outlet property="chattingInputStackView" destination="JcR-5o-DiP" id="lDv-9C-jgs"/>
                         <outlet property="chattingTextField" destination="o50-vy-lbP" id="pDR-5e-edJ"/>
                         <outlet property="containerViewBottomConstraint" destination="ODB-MH-Tcl" id="UcB-4b-CDa"/>
+                        <outlet property="disclaimerLabel" destination="3Dn-0Q-cLi" id="M9f-cX-R25"/>
                         <outlet property="headerView" destination="pb1-hy-Jgy" id="ni0-tM-QuI"/>
                         <outlet property="sendButton" destination="Jhw-LG-ZoI" id="CFe-Za-2Lz"/>
                         <outlet property="tableView" destination="Sjn-mm-DvB" id="kml-mG-8HL"/>

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -21,7 +21,9 @@ final class ChatbotViewController: CoreGradientViewController {
 	@IBOutlet private weak var containerViewBottomConstraint: NSLayoutConstraint!
 	@IBOutlet private weak var chattingInputStackView: UIStackView!
 	@IBOutlet private weak var chattingContainerStackView: UIStackView!
+	@IBOutlet weak var chattingInputContainer: UIStackView!
 	@IBOutlet private weak var chattingTextField: UITextField!
+	@IBOutlet weak var disclaimerLabel: UILabel!
 	@IBOutlet private weak var sendButton: UIButton!
 	
 	// MARK: 로그 확인용 및 마스킹 적용 PrivacyService 주입
@@ -141,6 +143,38 @@ final class ChatbotViewController: CoreGradientViewController {
 		automaticallyAdjustsScrollViewInsets = false
 	}
 	
+	override func setupConstraints() {
+		super.setupConstraints()
+		// 바깥 컨테이너(SafeArea 꽉)
+		
+		// ✅ 부모 스택뷰 내부 여백: 위 8, 좌우 16, 아래 12(라벨 잘림 방지)
+			chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
+			if #available(iOS 11.0, *) {
+				chattingContainerStackView.directionalLayoutMargins =
+					NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 12, trailing: 16)
+			} else {
+				chattingContainerStackView.layoutMargins =
+					UIEdgeInsets(top: 8, left: 16, bottom: 12, right: 16)
+			}
+
+			// ✅ 스택 간격 8을 코드로도 보장(스토리보드 값과 동일)
+			chattingContainerStackView.spacing = 8
+
+			// ✅ "안쪽 컨테이너"만 좌우 16 유지: 부모의 layoutMarginsGuide에 붙여줌
+			chattingInputContainer.translatesAutoresizingMaskIntoConstraints = false
+			NSLayoutConstraint.activate([
+				chattingInputContainer.leadingAnchor.constraint(
+					equalTo: chattingContainerStackView.layoutMarginsGuide.leadingAnchor),
+				chattingInputContainer.trailingAnchor.constraint(
+					equalTo: chattingContainerStackView.layoutMarginsGuide.trailingAnchor)
+			])
+
+			// (선택) 라벨이 눌려서 잘리지 않도록
+			disclaimerLabel?.numberOfLines = 0
+			disclaimerLabel?.setContentCompressionResistancePriority(.required, for: .vertical)
+			disclaimerLabel?.setContentHuggingPriority(.required, for: .vertical)
+	}
+	
 	override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
 		super.traitCollectionDidChange(previousTraitCollection)
 		
@@ -242,33 +276,6 @@ final class ChatbotViewController: CoreGradientViewController {
 					self.tableView.reloadRows(at: [ip], with: .none)
 				}
 			}
-//			if self.streamingAIIndex == nil {
-//				let message = ChatMessage(text: "", type: .ai)
-//				self.streamingAIIndex = self.messages.count
-//				self.messages.append(message)
-//				let ip = self.indexPathForMessage(at: self.streamingAIIndex!)
-//				self.tableView.insertRows(at: [ip], with: .fade)
-//				
-//				// seed 렌더링: 셀 등장 시점에만 가볍게 한 번
-//				if let cell = self.tableView.cellForRow(at: ip) as? AIResponseCell {
-//					cell.configure(with: "", isFinal: false)
-//					// 타자기 효과
-//					// cell.setTypewriterEnabled(true)
-//				}
-//			}
-//			
-//			guard let idx = self.streamingAIIndex else { return }
-//			let cleanedChunk = FootnoteSanitizer.sanitize(
-//				chunk,
-//				inFootnote: &self.inFootnote,
-//				pendingOpenBracket: &self.pendingOpenBracket
-//			)
-//			self.messages[idx].text.append(cleanedChunk)
-//
-//			let ip = self.indexPathForMessage(at: idx)
-//			if let cell = self.tableView.cellForRow(at: ip) as? AIResponseCell {
-//				cell.appendText(cleanedChunk)
-//			}
 		}
 		
 		viewModel.onStreamCompleted = { [weak self] finalText in
@@ -314,10 +321,10 @@ final class ChatbotViewController: CoreGradientViewController {
 	}
 	
 	private func setupStackViewStyles() {
-		chattingContainerStackView.layer.cornerRadius = 12
-		chattingContainerStackView.layer.masksToBounds = true
-		chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
-		chattingContainerStackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
+		chattingContainerStackView.layer.cornerRadius = 0
+		chattingContainerStackView.layer.masksToBounds = false
+		chattingContainerStackView.isLayoutMarginsRelativeArrangement = false
+		chattingContainerStackView.layoutMargins = .zero
 		
 		chattingInputStackView.backgroundColor = .boxBg
 		chattingInputStackView.layer.cornerRadius = 12

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -14,7 +14,7 @@ import os
 final class ChatbotViewController: CoreGradientViewController {
 	// MARK: - Outlets & Dependencies
 	@Injected private var viewModel: ChatbotViewModel
-	private var headerHeight: CGFloat = 64   // 필요시 64~80 조정
+	private var headerHeight: CGFloat = 44
 	
 	@IBOutlet weak var headerView: ChatbotHeaderTitleView!
 	@IBOutlet private weak var tableView: UITableView!
@@ -145,34 +145,28 @@ final class ChatbotViewController: CoreGradientViewController {
 	
 	override func setupConstraints() {
 		super.setupConstraints()
-		// 바깥 컨테이너(SafeArea 꽉)
+		chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
+		if #available(iOS 11.0, *) {
+			chattingContainerStackView.directionalLayoutMargins =
+			NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 12, trailing: 16)
+		} else {
+			chattingContainerStackView.layoutMargins =
+			UIEdgeInsets(top: 8, left: 16, bottom: 12, right: 16)
+		}
 		
-		// ✅ 부모 스택뷰 내부 여백: 위 8, 좌우 16, 아래 12(라벨 잘림 방지)
-			chattingContainerStackView.isLayoutMarginsRelativeArrangement = true
-			if #available(iOS 11.0, *) {
-				chattingContainerStackView.directionalLayoutMargins =
-					NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 12, trailing: 16)
-			} else {
-				chattingContainerStackView.layoutMargins =
-					UIEdgeInsets(top: 8, left: 16, bottom: 12, right: 16)
-			}
-
-			// ✅ 스택 간격 8을 코드로도 보장(스토리보드 값과 동일)
-			chattingContainerStackView.spacing = 8
-
-			// ✅ "안쪽 컨테이너"만 좌우 16 유지: 부모의 layoutMarginsGuide에 붙여줌
-			chattingInputContainer.translatesAutoresizingMaskIntoConstraints = false
-			NSLayoutConstraint.activate([
-				chattingInputContainer.leadingAnchor.constraint(
-					equalTo: chattingContainerStackView.layoutMarginsGuide.leadingAnchor),
-				chattingInputContainer.trailingAnchor.constraint(
-					equalTo: chattingContainerStackView.layoutMarginsGuide.trailingAnchor)
-			])
-
-			// (선택) 라벨이 눌려서 잘리지 않도록
-			disclaimerLabel?.numberOfLines = 0
-			disclaimerLabel?.setContentCompressionResistancePriority(.required, for: .vertical)
-			disclaimerLabel?.setContentHuggingPriority(.required, for: .vertical)
+		chattingContainerStackView.spacing = 8
+		
+		chattingInputContainer.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate([
+			chattingInputContainer.leadingAnchor.constraint(
+				equalTo: chattingContainerStackView.layoutMarginsGuide.leadingAnchor),
+			chattingInputContainer.trailingAnchor.constraint(
+				equalTo: chattingContainerStackView.layoutMarginsGuide.trailingAnchor)
+		])
+		
+		disclaimerLabel?.numberOfLines = 0
+		disclaimerLabel?.setContentCompressionResistancePriority(.required, for: .vertical)
+		disclaimerLabel?.setContentHuggingPriority(.required, for: .vertical)
 	}
 	
 	override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Health/Presentation/Chatbot/ChatbotViewController.swift
+++ b/Health/Presentation/Chatbot/ChatbotViewController.swift
@@ -159,22 +159,28 @@ final class ChatbotViewController: CoreGradientViewController {
 	private func observeNetworkStatusChanges() {
 		networkStatusObservationTask = Task {
 			for await isConnected in await NetworkMonitor.shared.networkStatusStream() {
-				if isConnected {
-					if wasPreviouslyDisconnected {
-						showWarningToast(
-							title: "네트워크 연결이 복구되었습니다.",
-							message: "계속해서 대화를 이어가세요 😊",
-							duration: 2.5
+				await MainActor.run {
+					if isConnected {
+						if wasPreviouslyDisconnected {
+							showToastAboveKeyboard(
+								type: .success,
+								title: "네트워크 연결이 복구되었습니다.",
+								message: "계속해서 대화를 이어가세요 😊",
+								duration: 2.5,
+								keyboardHeight: currentKeyboardHeight
+							)
+							wasPreviouslyDisconnected = false
+						}
+					} else {
+						showToastAboveKeyboard(
+							type: .warning,
+							title: "네트워크 연결 상태를 확인해주세요.",
+							message: "와이파이나 셀룰러 데이터 연결상태를 확인해주세요.",
+							duration: 3.0,
+							keyboardHeight: currentKeyboardHeight
 						)
-						wasPreviouslyDisconnected = false
+						wasPreviouslyDisconnected = true
 					}
-				} else {
-					showWarningToast(
-						title: "네트워크 연결 상태를 확인해주세요.",
-						message: "와이파이나 셀룰러 데이터 연결상태를 확인해주세요.",
-						duration: 3.0
-					)
-					wasPreviouslyDisconnected = true
 				}
 			}
 		}

--- a/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleView.swift
+++ b/Health/Presentation/Chatbot/Views/Cells/ChatbotHeaderTitleView.swift
@@ -31,7 +31,7 @@ final class ChatbotHeaderTitleView: CoreView {
 	private lazy var closeButton: UIButton = {
 		var config = UIButton.Configuration.plain()
 		config.image = UIImage(systemName: "xmark.circle.fill")
-		config.baseForegroundColor = .label
+		config.baseForegroundColor = .secondaryLabel
 		config.preferredSymbolConfigurationForImage =
 		UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .default)
 		config.contentInsets = NSDirectionalEdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1)

--- a/HealthWidget/Info.plist
+++ b/HealthWidget/Info.plist
@@ -9,5 +9,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>Widget Bundle Identifier</key>
+	<string>$(WIDGET_BUNDLE_IDENTIFIER)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 아이폰에서 키보드에서 가려지던 챗봇 맞춤 토스터블 메시지 위치 수정
- 위젯 관련 빌드 세팅 수정 > info에 xcconfig 환경변수 Widget bundle identifie, app group identifier 설정 
- 챗봇 채팅창 UI 수정 > 기존에 라이트 모드에서 쉐도우 잘린건 Container safeArea 0으로 변경해 늘림, 상단 Container에도 8 여백 추가

---

## 🧪 테스트시 유의 사항

- debug, release에서 혹은 아이패드에서 network 유실 복구시 뜨는 위치 확인 부탁드립니다.
- 채팅창 텍스트 필드 변경 사항 확인 부탁드립니다(다크모드, 라이트모드시 이상한 점 없는지)

---

## 📝 참고

- 

---

## 🌈 이미지

| 1 - 키보드 dismiss | 2 - 키보드 present   |
| :-:| :-: |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/dc919858-7088-450d-9ac7-bb7be85a6f71" /> | <img width="300"  alt="image" src="https://github.com/user-attachments/assets/c6be5cef-d8d0-4143-b9e5-28ebde36b38e" /> |



|아이패드 때 상단 토스트|
|:--:|
| <img width="800" alt="image" src="https://github.com/user-attachments/assets/35c8812f-cbcb-4141-8c1f-05a29aca2662" />|


|챗봇 - 채팅창 UI 수정 - 라이트 | 다크 - 키보드 present| 다크 - 키보드 dismiss 
|:--:|:--:|:--:|
|<img width="300" alt="simulator_screenshot_99F7D6B4-5875-4A9B-AB9C-698CCA7ED64E" src="https://github.com/user-attachments/assets/43b051bf-42c4-4923-89dc-61860dacbb72" /> |<img width="300" alt="simulator_screenshot_CDD00A93-EA13-4A13-B359-A574B8118356" src="https://github.com/user-attachments/assets/27516bca-f791-480c-b3d4-a1e8001e2c2d" />| <img width="300" alt="simulator_screenshot_67A0598C-AB20-4D69-B4B9-86012C0C747E" src="https://github.com/user-attachments/assets/1d071310-058a-4147-9317-74ce77019832" />|





---


### 💜 결과

-
