### PR TITLE
fix: 프로필 탭에서 건강 앱 연동 해제시, 캘린더 탭 달력 데이터 숨기기

### DIFF
--- a/Health/Core/Utils/Notification+Name.swift
+++ b/Health/Core/Utils/Notification+Name.swift
@@ -12,6 +12,9 @@ extension Notification.Name {
     /// 프로필 화면에서 `목표 걸음 수` 데이터가 갱신되었음을 알리는 알림 이름입니다.
     static let didUpdateGoalStepCount = Notification.Name("didUpdateGoalStepCount")
 
+    /// 프로필 화면에서 `Apple 건강 앱` 연동 스위치 상태가 갱신되었음을 알리는 알림 이름입니다.
+    static let didChangeHealthLinkStatusOnProfile = Notification.Name("didChangeHealthLinkStatusOnProfile")
+
     /// 걸음 수 데이터 동기화가 완료되었을 때 발송되는 알림
     ///
     /// 이 알림은 `DefaultStepSyncService.syncSteps()` 메서드가 성공적으로 완료된 후

--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -17,13 +17,6 @@ struct ProfileCellModel {
     var switchState: Bool = UserDefaultsWrapper.shared.healthkitLinked
 }
 
-
-// TODO: - 건강 권한 끌때는 얼럿 없애기
-// 다 꺼져있을때만 스위치 OFF -> ON으로 할때 ALERT
-// 하나라도 켜져있으면 ALERT 없이 스위치만 변경
-// 알림에선 확인 -> 설정
-//        취소 -> 스위치 원상복구
-
 class ProfileViewController: HealthNavigationController, Alertable {
     
     @IBOutlet weak var tableView: UITableView!
@@ -119,7 +112,7 @@ class ProfileViewController: HealthNavigationController, Alertable {
         stopForegroundGrantSync()
         
         grantRecheckObserver = NotificationCenter.default.addObserver(
-            forName: UIApplication.didBecomeActiveNotification,
+            forName: UIApplication.willEnterForegroundNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -148,7 +141,6 @@ class ProfileViewController: HealthNavigationController, Alertable {
     }
     
     // MARK: - UserDefaults는 쓸지안쓸지 아직모르겠음
-    // TODO: - 권한 있는지 없는지 Notification 뿌리기
     @objc private func switchChanged(_ sender: UISwitch) {
         if sender.isOn {
             // OFF -> ON
@@ -172,6 +164,13 @@ class ProfileViewController: HealthNavigationController, Alertable {
             UserDefaultsWrapper.shared.healthkitLinked = false
             updateSectionItemsForHealthSwitch(to: false)
         }
+
+        // 건강 앱 연동 스위치 상태가 변경되었음을 알림
+        NotificationCenter.default.post(
+            name: .didChangeHealthLinkStatusOnProfile,
+            object: nil,
+            userInfo: [.status: sender.isOn]
+        )
     }
     
     private func startGrantRecheckAfterReturning(switch sender: UISwitch) {


### PR DESCRIPTION
## 작업내용
프로필 탭에서 건강 앱 연동을 끄는 경우, 캘린더 탭 달력에도 즉시 반영하도록 합니다.