### PR TITLE
fix: 맞춤케어 탭 코스 설명의 디자인을 GuideView와 동기화

### DIFF
--- a/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
@@ -9,6 +9,17 @@ import UIKit
 
 final class CourseInfoView: UIView {
 
+    // GuideView.Configuration과 동기화
+    struct Constants {
+        static let titleFont: UIFont = .preferredFont(forTextStyle: .headline)
+        static let descriptionFont: UIFont = .preferredFont(forTextStyle: .body)
+        static let titleColor: UIColor = .label
+        static let descritionColor: UIColor = .secondaryLabel
+        static let contentSpacing: CGFloat = 4
+        static let sectionSpacing: CGFloat = 16
+        static let margin: CGFloat = 8
+    }
+
     private let stackView = UIStackView()
 
     var course: WalkingCourse? = nil {
@@ -30,15 +41,15 @@ final class CourseInfoView: UIView {
 
         addSubview(stackView)
         stackView.axis = .vertical
-        stackView.spacing = 16
+        stackView.spacing = Constants.sectionSpacing
         stackView.alignment = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.margin),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.margin),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.margin),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.margin)
         ])
     }
 
@@ -77,8 +88,8 @@ final class CourseInfoView: UIView {
         let containerView = UIView()
 
         let titleLabel = UILabel()
-        titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
-        titleLabel.textColor = .label
+        titleLabel.font = Constants.titleFont
+        titleLabel.textColor = Constants.titleColor
         titleLabel.text = title
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
@@ -89,8 +100,8 @@ final class CourseInfoView: UIView {
         let attributedString = NSAttributedString(
             string: content,
             attributes: [
-                .font: UIFont.preferredFont(forTextStyle: .body),
-                .foregroundColor: UIColor.secondaryLabel,
+                .font: Constants.descriptionFont,
+                .foregroundColor: Constants.descritionColor,
                 .paragraphStyle: paragraphStyle
             ]
         )
@@ -107,7 +118,7 @@ final class CourseInfoView: UIView {
             titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
 
-            contentLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            contentLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constants.contentSpacing),
             contentLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             contentLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             contentLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)

--- a/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
+++ b/Health/Presentation/Personal/Views/SubView/CourseInfoView.swift
@@ -14,7 +14,7 @@ final class CourseInfoView: UIView {
         static let titleFont: UIFont = .preferredFont(forTextStyle: .headline)
         static let descriptionFont: UIFont = .preferredFont(forTextStyle: .body)
         static let titleColor: UIColor = .label
-        static let descritionColor: UIColor = .secondaryLabel
+        static let descriptionColor: UIColor = .secondaryLabel
         static let contentSpacing: CGFloat = 4
         static let sectionSpacing: CGFloat = 16
         static let margin: CGFloat = 8
@@ -101,7 +101,7 @@ final class CourseInfoView: UIView {
             string: content,
             attributes: [
                 .font: Constants.descriptionFont,
-                .foregroundColor: Constants.descritionColor,
+                .foregroundColor: Constants.descriptionColor,
                 .paragraphStyle: paragraphStyle
             ]
         )


### PR DESCRIPTION
## 작업내용
- 맞춤 케어 탭 코스 설명 시트 내 디자인을 가이드뷰와 동일하게 적용하였습니다.

## 스크린샷
| 가이드뷰 | 코스 설명 - Before | 코스 설명 - After |
| -- | -- | -- |
| <img width="1206" height="2622" alt="simulator_screenshot_EA95D51C-D561-40C0-A513-B4CD41D45DCC" src="https://github.com/user-attachments/assets/a10f5833-4314-4a9d-9c0a-b5aba4c1a709" /> | <img width="1206" height="2622" alt="simulator_screenshot_2F726443-075F-4C61-AB39-F19D45F32BCE" src="https://github.com/user-attachments/assets/93c76472-78c6-49d1-ad30-ce68dc4d8886" /> | <img width="1206" height="2622" alt="simulator_screenshot_869B9090-9447-4B84-86FC-2C5969D7518B" src="https://github.com/user-attachments/assets/dee370e7-505e-4860-8c76-c7c10e2b790f" /> |

