### PR TITLE
fix: Personal- 프로필에서 스위치 on, off 하면 건강 권한 오류 화면도 연동되도록 수정 + 코스 난이도 제대로 불러오지 못하는 버그 해결

### DIFF
--- a/Health/Core/Storage/UserDefaults/UserDefaultsKeys.swift
+++ b/Health/Core/Storage/UserDefaults/UserDefaultsKeys.swift
@@ -56,5 +56,12 @@ extension UserDefaultsKeys {
             defaultValue: nil
         )
     }
-	
+
+    /// 사용자 정보 변경 감지를 위한 해시값 저장
+    var lastUserInfoHash: UserDefaultsKey<String?> {
+        UserDefaultsKey<String?>(
+            "LastUserInfoHash",
+            defaultValue: nil
+        )
+    }
 }

--- a/Health/Presentation/Personal/PersonalViewController.swift
+++ b/Health/Presentation/Personal/PersonalViewController.swift
@@ -66,6 +66,9 @@ class PersonalViewController: HealthNavigationController, Alertable, ScrollableT
         super.viewWillAppear(animated)
         // 앱이 포그라운드로 돌아올 때마다 권한 상태 확인
         checkLocationPermissionChange()
+        Task {
+            await llmViewModel.checkAndUpdateIfNeeded()
+        }
     }
 
     override func setupAttribute() {

--- a/Health/Presentation/Personal/Views/MainView/AISummaryCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/AISummaryCell.swift
@@ -14,7 +14,7 @@ class AISummaryCell: CoreCollectionViewCell {
     @IBOutlet weak var aiSummaryLabel: UILabel!
     @IBOutlet weak var summaryBackgroundView: UIView!
     @IBOutlet weak var backgroundHeight: NSLayoutConstraint!
-    
+
     private let loadingIndicatorView = AlanLoadingIndicatorView()
     private var viewModel: AIMonthlySummaryCellViewModel?
     private var cancellables = Set<AnyCancellable>()
@@ -25,7 +25,7 @@ class AISummaryCell: CoreCollectionViewCell {
             setupLoadingIndicator()
         }
     }
-    
+
     override func setupAttribute() {
         super.setupAttribute()
         BackgroundHeightUtils.setupShadow(for: self)
@@ -36,29 +36,27 @@ class AISummaryCell: CoreCollectionViewCell {
     private func setupLoadingIndicator() {
         summaryBackgroundView.addSubview(loadingIndicatorView)
         loadingIndicatorView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         NSLayoutConstraint.activate([
             loadingIndicatorView.centerXAnchor.constraint(equalTo: summaryBackgroundView.centerXAnchor, constant: 0),
             loadingIndicatorView.centerYAnchor.constraint(equalTo: summaryBackgroundView.centerYAnchor, constant: 0),
             loadingIndicatorView.widthAnchor.constraint(greaterThanOrEqualToConstant: 200),
-//            loadingIndicatorView.widthAnchor.constraint(equalToConstant: 300),
-//            loadingIndicatorView.heightAnchor.constraint(equalToConstant: 70)
             loadingIndicatorView.leadingAnchor.constraint(greaterThanOrEqualTo: summaryBackgroundView.leadingAnchor, constant: 16),
             loadingIndicatorView.trailingAnchor.constraint(lessThanOrEqualTo: summaryBackgroundView.trailingAnchor, constant: -16)
         ])
     }
-    
+
     override func setupConstraints() {
         super.setupConstraints()
         BackgroundHeightUtils.updateBackgroundHeight(constraint: backgroundHeight, in: self)
-        
+
         registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
             BackgroundHeightUtils.updateBackgroundHeight(constraint: self.backgroundHeight, in: self)
         }
     }
-    
+
     // MARK: - Configuration
-    
+
     func configure(
         with viewModel: AIMonthlySummaryCellViewModel,
         promptBuilderService: any PromptBuilderService
@@ -66,7 +64,7 @@ class AISummaryCell: CoreCollectionViewCell {
         self.viewModel = viewModel
         cancellables.removeAll()
         render(for: .loading)
-        
+
         // 상태 변화 구독
         viewModel.statePublisher
             .receive(on: DispatchQueue.main)
@@ -74,17 +72,17 @@ class AISummaryCell: CoreCollectionViewCell {
                 self?.render(for: state)
             }
             .store(in: &cancellables)
-        
+
         // 월간 요약 로딩 시작
         Task {
             await viewModel.loadMonthlySummary()
         }
     }
-    
+
     // MARK: - State Handling
-    
+
     private func render(for state: LoadState<AIMonthlySummaryCellViewModel.Content>) {
-        
+
         switch state {
         case .idle:
             aiSummaryLabel.isHidden = true
@@ -120,13 +118,13 @@ class AISummaryCell: CoreCollectionViewCell {
             chatbotView.isHidden = true
         }
     }
-    
+
     override func prepareForReuse() {
         super.prepareForReuse()
-        
+
         cancellables.removeAll()
         viewModel = nil
-        
+
         // 초기 상태로 리셋
         aiSummaryLabel.isHidden = true
         loadingIndicatorView.setState(.loading)

--- a/Health/ViewModels/Cells/MonthSummaryCellViewModel.swift
+++ b/Health/ViewModels/Cells/MonthSummaryCellViewModel.swift
@@ -60,6 +60,12 @@ final class MonthSummaryCellViewModel: ObservableObject {
         state = .loading
 
         Task { @MainActor in
+
+            guard UserDefaultsWrapper.shared.healthkitLinked else {
+                state = .denied
+                return
+            }
+
             // 권한 체크 (걸음수 + 거리 + 칼로리 모두 필요)
             let hasStepPermission = await healthService.checkHasReadPermission(for: .stepCount)
             let hasDistancePermission = await healthService.checkHasReadPermission(for: .distanceWalkingRunning)

--- a/Health/ViewModels/Cells/MonthSummaryCellViewModel.swift
+++ b/Health/ViewModels/Cells/MonthSummaryCellViewModel.swift
@@ -39,6 +39,20 @@ final class MonthSummaryCellViewModel: ObservableObject {
                 self?.loadMonthlyData()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .sink { [weak self] _ in
+                let isLinked = UserDefaultsWrapper.shared.healthkitLinked
+
+                if isLinked {
+                    // 연동 ON
+                    self?.loadMonthlyData()
+                } else {
+                    // 연동 OFF
+                    self?.state = .denied
+                }
+            }
+            .store(in: &cancellables)
     }
 
     /// 월간 데이터 로드

--- a/Health/ViewModels/Cells/WeekSummaryCellViewModel.swift
+++ b/Health/ViewModels/Cells/WeekSummaryCellViewModel.swift
@@ -10,7 +10,7 @@ import Combine
 import HealthKit
 
 final class WeekSummaryCellViewModel: ObservableObject {
-    
+
     // 상태관리
     enum LoadState {
         case idle
@@ -19,18 +19,18 @@ final class WeekSummaryCellViewModel: ObservableObject {
         case denied    // 권한 없음 (걸음수 또는 거리 권한 중 하나라도 없음)
         case failure
     }
-    
+
     @Published var state: LoadState = .idle
-    
+
     @Injected(.healthService) private var healthService: HealthService
     private let healthDataViewModel = HealthDataViewModel()
-    
+
     private static var cachedWeeklyData: WeeklyHealthData?
     private static var lastCacheTime: Date?
     private static let cacheTimeout: TimeInterval = 300 // 5분
-    
+
     private var cancellables = Set<AnyCancellable>()
-    
+
     init() {
         //  앱이 포그라운드로 돌아올 때 권한 재체크
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
@@ -38,26 +38,40 @@ final class WeekSummaryCellViewModel: ObservableObject {
                 self?.loadWeeklyData()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .sink { [weak self] _ in
+                let isLinked = UserDefaultsWrapper.shared.healthkitLinked
+
+                if isLinked {
+                    // 연동 ON
+                    self?.loadWeeklyData()
+                } else {
+                    // 연동 OFF
+                    self?.state = .denied
+                }
+            }
+            .store(in: &cancellables)
     }
-    
+
     /// 주간 데이터 로드
     func loadWeeklyData() {
         state = .loading
-        
+
         Task { @MainActor in
-            
+
             //(걸음수 + 거리 둘 다 필요)
             let hasStepPermission = await healthService.checkHasReadPermission(for: .stepCount)
             let hasDistancePermission = await healthService.checkHasReadPermission(for: .distanceWalkingRunning)
-            
+
             // 둘 다 허용되어야만 권한 있음
             let hasAllPermissions = hasStepPermission && hasDistancePermission
-            
+
             guard hasAllPermissions else {
                 state = .denied
                 return
             }
-            
+
             //캐시처리
             if let cached = Self.cachedWeeklyData,
                let lastTime = Self.lastCacheTime,
@@ -65,26 +79,26 @@ final class WeekSummaryCellViewModel: ObservableObject {
                 state = .success(cached)
                 return
             }
-            
+
             let weeklyData = await healthDataViewModel.getWeeklyHealthData()
             Self.cachedWeeklyData = weeklyData
             Self.lastCacheTime = Date()
             state = .success(weeklyData)
         }
     }
-    
+
     /// 권한 요청
     func requestPermission() async -> Bool {
         do {
             _ = try await healthService.requestAuthorization()
         } catch {
         }
-        
+
         // 권한 요청 후 다시 체크
         let hasStepPermission = await healthService.checkHasReadPermission(for: .stepCount)
         let hasDistancePermission = await healthService.checkHasReadPermission(for: .distanceWalkingRunning)
         let hasAllPermissions = hasStepPermission && hasDistancePermission
-        
+
         if hasAllPermissions {
             // 권한 허용되면 자동으로 데이터 로드
             await MainActor.run {

--- a/Health/ViewModels/Cells/WeekSummaryCellViewModel.swift
+++ b/Health/ViewModels/Cells/WeekSummaryCellViewModel.swift
@@ -60,6 +60,11 @@ final class WeekSummaryCellViewModel: ObservableObject {
 
         Task { @MainActor in
 
+            guard UserDefaultsWrapper.shared.healthkitLinked else {
+                state = .denied
+                return
+            }
+
             //(걸음수 + 거리 둘 다 필요)
             let hasStepPermission = await healthService.checkHasReadPermission(for: .stepCount)
             let hasDistancePermission = await healthService.checkHasReadPermission(for: .distanceWalkingRunning)


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 프로필에서 건강 권한 on, off에 따라 일주일, 한달 요약셀이 보이고 안보이도록 수정했습니다.
- 프로필화면에서 신체 정보 수정하면 CoreData에도 저장되도록 수정했습니다. @haejaejoon 
- 신체정보 수정해도 난이도가 잘 바뀌지 않는 버그 수정했습니다.

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- print문은 프롬프트 테스트 조금 더 해보고 정리 하겠습니다.
- 테스트 할때 프로필 탭에서 사용자 신체 정보 바꾸고 다시 맞춤 탭으로 돌아가서 난이도가 잘 바뀌는지 테스트 해주시면 감사하겠습니다.

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |

https://github.com/user-attachments/assets/b7f749e3-32ad-4c76-94ba-a0cd94ad9c64


|    |     |

---

### 💜 결과

-
