### PR TITLE
fix: 태어난해 Picker 현재년도 -1까지 나오게, 목표걸음 500씩으로 변경

### DIFF
--- a/Health/Presentation/Profile/Views/EditBirthdayView.swift
+++ b/Health/Presentation/Profile/Views/EditBirthdayView.swift
@@ -58,7 +58,7 @@ class EditBirthdayView: CoreView {
     
     private func setupYears() {
         let currentYear = Calendar.current.component(.year, from: Date())
-        years = Array(1900...currentYear)
+        years = Array(1900...(currentYear - 1))
     }
     
     private func setupPicker() {

--- a/Health/Presentation/Profile/Views/EditStepGoalView.swift
+++ b/Health/Presentation/Profile/Views/EditStepGoalView.swift
@@ -39,7 +39,7 @@ final class EditStepGoalView: CoreView {
     private let minHapticInterval: CFTimeInterval = 0.07
 
     
-    var step: Int = 100
+    var step: Int = 500
     var minValue: Int = 500
     var maxValue: Int = 100_000
     var onValueChanged: ((Int) -> Void)?
@@ -179,7 +179,7 @@ final class EditStepGoalView: CoreView {
         plusButton.isEnabled  = value < maxValue
     }
     
-    func configure(defaultValue: Int, step: Int = 100, min: Int = 500, max: Int = 100_000) {
+    func configure(defaultValue: Int, step: Int = 500, min: Int = 500, max: Int = 100_000) {
         self.step = step
         self.minValue = min
         self.maxValue = max


### PR DESCRIPTION

## ✅ 변경사항

- 목표걸음 변경 단위 500으로 변경
- 태어난 해는 작년까지만 나오게 변경

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|    |     |

---

### 💜 결과

-
