### PR TITLE
fix: 캘린더 탭 달력 셀 프로그레스 바에 의도치 않은 애니메이션 발생하는 문제 수정

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarProgressBar.swift
+++ b/Health/Presentation/Calendar/Views/CalendarProgressBar.swift
@@ -6,7 +6,10 @@ final class CalendarProgressBar: CoreView {
 
     var progress: CGFloat = 0 {
         didSet {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true) // 암시적 애니메이션 제거
             progressLayer.strokeEnd = min(max(progress, 0), 1)
+            CATransaction.commit()
         }
     }
 


### PR DESCRIPTION
## 작업내용
캘린더 탭을 처음 열거나 포그라운드 상태로 진입할 때
달력의 프로그레스바가 순간적으로 가득 찼다가 줄어드는 의도되지 않은 애니메이션을 제거했습니다.

## 링크
[노션 - QA](https://www.notion.so/oreumi/25cebaa8982b80c5b240c0045f75a176?v=242ebaa8982b8158aea0000cba0038c6&source=copy_link)