### PR TITLE
fix: 프로필에서 건강 스위치를 `on`하더라도 대시보드가 실시간으로 갱신되지 않는 문제 수정

### DIFF
--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -134,7 +134,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
     @objc private func refreshHKData() {
         viewModel.loadHKData(includeAI: true, updateAnchorDate: true)
         Task.detached { await self.viewModel.updateWidgetSnapshot() }
-        Task.delay(for: 1.0) { @MainActor in refreshControl.endRefreshing() }
+        Task.delay(for: 0.6) { @MainActor in refreshControl.endRefreshing() }
     }
 
 

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -120,7 +120,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(reloadHKData(_:)),
+            selector: #selector(refreshHKData),
             name: .didChangeHealthLinkStatusOnProfile,
             object: nil
         )
@@ -135,12 +135,6 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         viewModel.loadHKData(includeAI: true, updateAnchorDate: true)
         Task.detached { await self.viewModel.updateWidgetSnapshot() }
         Task.delay(for: 1.0) { @MainActor in refreshControl.endRefreshing() }
-    }
-    
-    @objc private func reloadHKData(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let state = userInfo["status"] as? Bool else { return }
-        if !state { refreshHKData() }
     }
 
 

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -111,7 +111,7 @@ extension HealthInfoStackCollectionViewCell {
 
             if let charts = content.charts, !charts.isEmpty {
                 sizeClasses(vRhR: {
-                        self.addChartsHostingController(with: charts, parent: parent)
+                    self.addChartsHostingController(with: charts, parent: parent)
                 })
             }
 
@@ -132,7 +132,7 @@ extension HealthInfoStackCollectionViewCell {
     }
 
     private func formatValue(kind: DashboardStackKind, value: Double) -> String {
-        if value == 0.0 {
+        if value < 0.1 {
             return "0"
         } else {
             switch kind {


### PR DESCRIPTION
@haejaejoon 

## ✅ 변경사항

- 프로필 화면에서 건강 권한 스위치를 `on`으로 바꾸더라도 대시보드가 실시간으로 갱신되지 않는 문제를 수정했습니다.
- 대시보드의 상단 셀(걸은 거리, 운동 시간)의 값이 0.0222인 경우, 0.0으로 표시되는 문제를 수정했습니다. (이제는 0으로 표시) 

---

## 🌈 이미지

https://github.com/user-attachments/assets/5cb0cf24-f22c-46cd-96d3-0147305a88bf