### PR TITLE
feat: 걸음 수 Label에 monospace 적용

### DIFF
--- a/Health/Presentation/Profile/Views/EditStepGoalView.swift
+++ b/Health/Presentation/Profile/Views/EditStepGoalView.swift
@@ -122,7 +122,8 @@ final class EditStepGoalView: CoreView {
         valueStack.alignment = .center
         valueStack.spacing = 8
         
-        valueLabel.font = .preferredFont(forTextStyle: .largeTitle)
+        let font = UIFont.monospacedDigitSystemFont(ofSize: 34, weight: .regular)
+        valueLabel.font = UIFontMetrics(forTextStyle: .largeTitle).scaledFont(for: font)
         valueLabel.adjustsFontForContentSizeCategory = true
         
         hStack.axis = .horizontal


### PR DESCRIPTION

## ✅ 변경사항

- 목표 걸음 수 Label이 변경 될 때 숫자의 폭이 달라서 움직이는 듯한 느낌이 들어서 숫자폭을 일관적으로 적용 했습니다.

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지
![ezgif-159f55fb26f094](https://github.com/user-attachments/assets/cf356986-7b91-413e-a967-46938a63cbc8)


---

### 💜 결과

-
