### PR TITLE
feat: 경고창 message 문구 통일 작업 + 네비게이션바 백버튼 상하좌우 터치 대응 되도록 여백 수정

### DIFF
--- a/Health/Presentation/Onboarding/Delegates/CustomOnboardingNaviBarView.swift
+++ b/Health/Presentation/Onboarding/Delegates/CustomOnboardingNaviBarView.swift
@@ -22,8 +22,9 @@ class CustomNavigationBarView: UIView {
         let button = UIButton(type: .system)
         let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
         let image = UIImage(systemName: "chevron.left", withConfiguration: config)
-//        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 20)
-        button.contentHorizontalAlignment = .left
+        
+        button.contentHorizontalAlignment = .center
+        button.contentVerticalAlignment = .center
         button.setImage(image, for: .normal)
         button.tintColor = .label
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -51,9 +52,11 @@ class CustomNavigationBarView: UIView {
     
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
+            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             backButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            backButton.widthAnchor.constraint(equalToConstant: 20),
+            backButton.widthAnchor.constraint(equalToConstant: 30),
+            backButton.heightAnchor.constraint(equalToConstant: 40),
+            
             
             progressIndicatorStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             progressIndicatorStackView.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/Health/Presentation/Onboarding/MainVC/HealthLinkViewController.swift
+++ b/Health/Presentation/Onboarding/MainVC/HealthLinkViewController.swift
@@ -154,8 +154,8 @@ class HealthLinkViewController: CoreGradientViewController, Alertable {
     }
     
     override func setupAttribute() {
-        userDescriptionLabel.text = "사용자 데이터 입력 및 \n건강 앱 정보 가져오기 권한 설정"
-        supUserDescriptionLabel.text = "신체 측정값을 가져와서 걸음 수를 Apple 건강 앱과 지속적으로 동기화 할 수 있습니다."
+        userDescriptionLabel.text = "사용자 정보 입력 및 \n건강 데이터 접근 권한 요청"
+        supUserDescriptionLabel.text = "AI가 걷기·활동 데이터를 분석해 맞춤 건강 정보를 제공합니다. 일일 걸음 수, 거리, 에너지를 기반으로 건강 상태를 파악하고 개인화된 추천을 위해 건강 데이터 접근이 필요합니다."
         linkSettingView.backgroundColor = UIColor(named: "boxBgColor")
         linkSettingView.applyCornerStyle(.medium)
         linkSettingView.clipsToBounds = true
@@ -221,8 +221,8 @@ class HealthLinkViewController: CoreGradientViewController, Alertable {
                     UserDefaultsWrapper.shared.healthkitLinked = false
                   
                     showAlert(
-                        "권한 설정",
-                        message: "건강앱 연동없이 앱 실행시, 일부기능이 제한될 수 있습니다. 건강 앱 화면으로 이동하시겠습니까?",
+                        "권한 설정 필요",
+                        message: "앱이 접근할 수 있는 건강 데이터가 없습니다.\n\n아래 경로에서 앱의 건강 데이터 접근 권한을 해제하거나 다시 활성화할 수 있습니다.\n\n프로필(우측 상단) ⏵ 개인정보 보호 ⏵ 앱 ⏵ Walkee",
                         primaryTitle: "열기",
                         onPrimaryAction: { _ in
                             self.openHealthApp()

--- a/Health/Presentation/Onboarding/Onboarding.storyboard
+++ b/Health/Presentation/Onboarding/Onboarding.storyboard
@@ -84,7 +84,7 @@
                                     <action selector="continueButtonTapped:" destination="hrK-kw-Dwx" eventType="touchUpInside" id="UGe-MW-VHk"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목표걸음을 입력해주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="35Y-V1-jNy">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목표 걸음 수를 설정해주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="35Y-V1-jNy">
                                 <rect key="frame" x="20" y="210" width="400" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
## #️⃣ 이슈번호

>

---

## ✅ 변경사항

 온보딩뷰 사용 네비게이션바 여백 조정 
- 기존 horizontal alignment - left -> center로 변경
- vertical alignment center 추가 
- leading constraints 18 -> 12 조정
- button.heightAnchor 추가

다른뷰에서 보이는 경고창 매세지와 문구, 어투 통일완료 (healthLinkVC, stepGoalVC)


---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|    |     |

---

### 💜 결과

-
