### PR TITLE
feat:온보딩과 UI 통일, 신체정보는 탭바 숨김

### DIFF
--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -88,11 +88,18 @@ class ProfileViewController: HealthNavigationController, Alertable {
         super.viewWillAppear(animated)
         let latest = goalStepCountVM.goalStepCount(for: Date()).map(Int.init) ?? 0
         currentGoalCache = latest
+        tabBarController?.tabBar.isHidden = false
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         startForegroundGrantSync()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "bodyInfo" {
+            tabBarController?.tabBar.isHidden = true
+        }
     }
     
     /// 앱이 포어그라운드로 복귀할 때마다 HealthKit 권한을 재확인하도록 옵저버를 등록합니다.
@@ -195,7 +202,7 @@ class ProfileViewController: HealthNavigationController, Alertable {
         showAlert(
             "권한 설정 안내",
             message: """
-                     앱이 접근할 수 있는 건강 데이터가 없습니다.\n\n아래 경로에서 앱의 건강 데이터 접근 권한을 해제하거나 다시 활성화할 수 있습니다.\n\n 프로필(우측 상단) ⏵ 개인정보 보호 ⏵ 앱 ⏵ Walkee
+                     앱이 접근할 수 있는 건강 데이터가 없습니다.\n\n아래 경로에서 앱의 건강 데이터 접근 권한을 해제하거나 다시 활성화할 수 있습니다.\n\n 프로필 ⏵ 개인정보 보호 ⏵ 앱 ⏵ Walkee
                      """,
             primaryTitle: "열기",
             onPrimaryAction: ({ [weak self] _ in

--- a/Health/Presentation/Profile/Views/EditGenderView.swift
+++ b/Health/Presentation/Profile/Views/EditGenderView.swift
@@ -103,8 +103,13 @@ final class EditGenderView: CoreView {
     }
     
     private func updateButtonConfig() {
-        femaleButton.backgroundColor = (selectedGender == .female) ? .accent : .buttonBackground
-        maleButton.backgroundColor = (selectedGender == .male) ? .accent : .buttonBackground
+        let selectedTextColor = UIColor.systemBackground
+        let defaultTextColor = UIColor.label
+        
+        femaleButton.backgroundColor = (selectedGender == .female) ? .accent : .boxBg
+        maleButton.backgroundColor = (selectedGender == .male) ? .accent : .boxBg
+        
+        femaleButton.setTitleColor((selectedGender == .female) ? selectedTextColor : defaultTextColor, for: .normal)
+        maleButton.setTitleColor((selectedGender == .male) ? selectedTextColor : defaultTextColor, for: .normal)
     }
-    
 }

--- a/Health/Presentation/Profile/Views/EditHeightView.swift
+++ b/Health/Presentation/Profile/Views/EditHeightView.swift
@@ -13,7 +13,7 @@ final class EditHeightView: CoreView {
     
     private let pickerView = UIPickerView()
     
-    private let heights: [Int] = Array(120...220)
+    private let heights: [Int] = Array(100...230)
     var selectedHeight: Int = 170
     
     override func setupHierarchy() {


### PR DESCRIPTION


## ✅ 변경사항

- 성별 선택 버튼 온보딩과 통일
- 키 몸무게 범위 온보딩과 통일
- 건강 권한 얼럿에서 "우측 상단" 뺌
- 신체정보View는 탭바 숨김

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지



---

### 💜 결과

-
