### PR TITLE
feat: 헬스킷에서 `오른 층수` 권한을 받도록 수정, 대시보드에서 운동 시간 대신 `오른 층수`가 표시되도록 수정

### DIFF
--- a/Health/Core/Protocols/ScrollableToTop.swift
+++ b/Health/Core/Protocols/ScrollableToTop.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// 탭바에서 같은 탭 재선택 시 최상단으로 스크롤하는 기능을 제공하는 프로토콜
+@MainActor
 protocol ScrollableToTop {
     /// 뷰를 최상단으로 스크롤합니다.
     func scrollToTop()

--- a/Health/Core/Views/CircleProgressView/CircleProgressView.swift
+++ b/Health/Core/Views/CircleProgressView/CircleProgressView.swift
@@ -98,6 +98,8 @@ final class CircleProgressView: CoreView {
     // 이 시점에서 기존 레이어를 제거하고 경로(Path)를 다시 그립니다.
     // 레이블 텍스트도 이와 함께 갱신합니다. (다른 적절한 업데이트 시점이 없기 때문입니다)
     override func layoutSubviews() {
+        super.layoutSubviews()
+
         drawStrokeCircle()
 
         if let currentValue = currentValue {
@@ -190,6 +192,9 @@ final class CircleProgressView: CoreView {
     }
 
     private func drawStrokeCircle() {
+        backgroundGradientLayer?.removeFromSuperlayer()
+        foregroundGradientLayer?.removeFromSuperlayer()
+
         let adjustedStartAngle = -90.radian
         
         drawStrokeCircle(
@@ -226,8 +231,6 @@ extension CircleProgressView {
         lineWidth: CGFloat
     ) {
         assert(!lightStrokeColors.isEmpty || !darkStrokeColors.isEmpty)
-
-        layer?.removeFromSuperlayer()
 
         let diameter = min(bounds.width, bounds.height)
         let center = CGPoint(x: bounds.midX, y: bounds.midY)

--- a/Health/Presentation/Dashboard/Content/Enum/DashboardStackKind.swift
+++ b/Health/Presentation/Dashboard/Content/Enum/DashboardStackKind.swift
@@ -17,6 +17,8 @@ enum DashboardStackKind: CaseIterable {
     case activeEnergyBurned
     ///
     case basalEnergyBurned
+    ///
+    case flightsClimbed
 }
 
 extension DashboardStackKind {
@@ -28,6 +30,7 @@ extension DashboardStackKind {
         case .appleExerciseTime:                return "운동 시간"
         case .activeEnergyBurned:               return "활동 에너지"
         case .basalEnergyBurned:                return "휴식 에너지"
+        case .flightsClimbed:                   return "오른 층수"
         }
     }
 
@@ -38,6 +41,7 @@ extension DashboardStackKind {
         case .appleExerciseTime:                return "timer"
         case .activeEnergyBurned:               return "flame.fill"
         case .basalEnergyBurned:                return "sleep.circle.fill"
+        case .flightsClimbed:                   return "figure.stairs"
         }
     }
 
@@ -48,6 +52,7 @@ extension DashboardStackKind {
         case .appleExerciseTime:              return HKUnit.minute()
         case .activeEnergyBurned:             return HKUnit.kilocalorie()
         case .basalEnergyBurned:              return HKUnit.kilocalorie()
+        case .flightsClimbed:                 return HKUnit.count()
         }
     }
 
@@ -58,6 +63,7 @@ extension DashboardStackKind {
         case .appleExerciseTime:              return "분"
         case .activeEnergyBurned:             return "kcal"
         case .basalEnergyBurned:              return "kcal"
+        case .flightsClimbed:                 return "층"
         }
     }
 
@@ -68,6 +74,7 @@ extension DashboardStackKind {
         case .appleExerciseTime:                return .appleExerciseTime
         case .activeEnergyBurned:               return .activeEnergyBurned
         case .basalEnergyBurned:                return .basalEnergyBurned
+        case .flightsClimbed:                   return .flightsClimbed
         }
     }
 }

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -35,7 +35,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         super.viewIsAppearing(animated)
 
         buildLayout()
-        loadData()
+//        loadData() // 생명주기 메서드에서 데이터를 로드하는 대신, 프로필 화면에서 노티피케이션 신호를 받으면 데이터를 로드합니다.
         setupDataSource()
         applySnapshot()
 
@@ -110,14 +110,15 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
             name: .didUpdateGoalStepCount,
             object: nil
         )
-        
+
+        // 생명주기 메서드에서 데이터를 로드하는 대신, 프로필 화면에서 노티피케이션 신호를 받으면 데이터를 로드합니다.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(refreshHKData),
             name: .didChangeHealthLinkStatusOnProfile,
             object: nil
         )
-        
+
         //        NotificationCenter.default.addObserver(
         //            self,
         //            selector: #selector(refreshHKData),

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -114,16 +114,16 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(refreshHKData),
-            name: .didChangeHKSharingAuthorizationStatus,
-            object: nil
-        )
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(refreshHKData),
             name: .didChangeHealthLinkStatusOnProfile,
             object: nil
         )
+        
+        //        NotificationCenter.default.addObserver(
+        //            self,
+        //            selector: #selector(refreshHKData),
+        //            name: .didChangeHKSharingAuthorizationStatus,
+        //            object: nil
+        //        )
     }
 
     private func shareActivityRingImage() {

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -101,7 +101,14 @@ extension HealthInfoCardCollectionViewCell {
             
         case let .success(content):
             let status = viewModel.evaluateGaitStatus(content.value)
-            statusProgressBarView.currentValue = content.value
+            statusProgressBarView.currentValue = {
+                switch viewModel.itemID.kind {
+                case .walkingSpeed, .walkingStepLength:
+                    return (content.value * 10).rounded() / 10.0
+                case .walkingAsymmetryPercentage, .walkingDoubleSupportPercentage:
+                    return content.value
+                }
+            }()
             statusProgressBarView.numberFormatter = {
                 switch viewModel.itemID.kind {
                 case .walkingSpeed:

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoStackCollectionViewCell.swift
@@ -135,7 +135,7 @@ extension HealthInfoStackCollectionViewCell {
             return "0"
         } else {
             switch kind {
-            case .appleExerciseTime:
+            case .appleExerciseTime, .flightsClimbed:
                 return String(format: "%.0f", value)
             default:
                 return String(format: "%.1f", value)

--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -93,6 +93,8 @@ class ProfileViewController: HealthNavigationController, Alertable {
     override func viewDidLoad() {
         super.viewDidLoad()
         startForegroundGrantSync()
+
+        Task { await recheckGrantAndSave() }
     }
     
     /// 앱이 포어그라운드로 복귀할 때마다 HealthKit 권한을 재확인하도록 옵저버를 등록합니다.

--- a/Health/Presentation/Profile/ProfileViewController.swift
+++ b/Health/Presentation/Profile/ProfileViewController.swift
@@ -116,11 +116,16 @@ class ProfileViewController: HealthNavigationController, Alertable {
     /// 현재 HealthKit 읽기 권한을 비동기로 재확인하고, UI/모델/저장을 동기화합니다.
     @MainActor
     private func recheckGrantAndSave() async {
-        print(#function, #line)
         let hasAny = await healthService.checkHasAnyReadPermission()
         UserDefaultsWrapper.shared.healthkitLinked = hasAny
         updateSectionItemsForHealthSwitch(to: hasAny)
         tableView.reloadData()
+        
+        NotificationCenter.default.post(
+            name: .didChangeHealthLinkStatusOnProfile,
+            object: nil,
+            userInfo: [.status: hasAny]
+        )
     }
     
     // MARK: - UserDefaults는 쓸지안쓸지 아직모르겠음

--- a/Health/Services/HealthService/DefaultHealthService.swift
+++ b/Health/Services/HealthService/DefaultHealthService.swift
@@ -31,7 +31,8 @@ final class DefaultHealthService: HealthService  {
             HKQuantityType(.walkingStepLength),                 // 보행 보폭
             HKQuantityType(.walkingAsymmetryPercentage),        // 보행 비대칭성
             HKQuantityType(.walkingSpeed),                      // 보행 속도
-            HKQuantityType(.walkingDoubleSupportPercentage)     // 이중 지지 시간
+            HKQuantityType(.walkingDoubleSupportPercentage),    // 이중 지지 시간
+            HKQuantityType(.flightsClimbed)                     // 오른 층수
         ]
     }
     

--- a/Health/Services/HealthService/MockHealthService.swift
+++ b/Health/Services/HealthService/MockHealthService.swift
@@ -74,6 +74,7 @@ final class MockHealthService: HealthService {
             .distanceWalkingRunning: 80.0,        // 걷기+달리기 거리 (km )
             .appleExerciseTime: 42.0,             // 운동 시간 (분)
             .stepCount: 8_540,                    // 걸음 수
+            .flightsClimbed: 13,                  // 오른 층수
             .walkingStepLength: 72,               // 보행 보폭 (cm)
             .walkingAsymmetryPercentage: 0.27,    // 보행 비대칭성 (%)
             .walkingSpeed: 1.32,                  // 보행 속도 (m/s)

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -97,7 +97,7 @@ final class DashboardViewModel {
     private func buildStackCells() {
         let newIDs = [
             HealthInfoStackCellViewModel.ItemID(kind: .distanceWalkingRunning),
-            HealthInfoStackCellViewModel.ItemID(kind: .appleExerciseTime),
+            HealthInfoStackCellViewModel.ItemID(kind: .flightsClimbed),
             HealthInfoStackCellViewModel.ItemID(kind: .activeEnergyBurned),
             HealthInfoStackCellViewModel.ItemID(kind: .basalEnergyBurned),
         ]
@@ -179,7 +179,7 @@ extension DashboardViewModel {
 
     func loadHKData(includeAI: Bool = true, updateAnchorDate: Bool = false) {
         loadAnchorDateForTopCell(updateAnchorDate: updateAnchorDate)
-        loadHKDataForGoalRingCells()
+        loadHKDataForActivityRingCells()
         loadHKDataForStackCells()
         loadHKDataForCardCells()
         loadHKDataForBarChartsCells()
@@ -196,7 +196,7 @@ extension DashboardViewModel {
         }
     }
 
-    func loadHKDataForGoalRingCells() {
+    func loadHKDataForActivityRingCells() {
         let (_, goalStepCount) = fetchCoreDataUser()
         
         Task {
@@ -248,8 +248,8 @@ extension DashboardViewModel {
                     continue
                 }
 
-                // 지난 7일 간 라인 차트를 그리기 위해 30일 전 시간 구하기
-                guard let startDate: Date = anchorDate.endOfDay().addingDays(-14) else {
+                // 지난 7일 간 라인 차트를 그리기 위해 100일 전 시간 구하기
+                guard let startDate: Date = anchorDate.endOfDay().addingDays(-100) else {
                     vm.setState(.failure(nil))
                     continue
                 }

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -490,8 +490,6 @@ extension DashboardViewModel {
             option: .dailySummary
         ) else { return nil }
         let response = await alanService.sendQuestion(prompt)
-//        print(response)
-//        print(response?.removingMarkdown())
         return response
     }
 	


### PR DESCRIPTION
> 변경사항이 조금 많습니다. 권한 상태에 따라서 값을 정확하게 잘 불러오는지 위주로 테스트하였습니다. 기타 자잘하게 눈엣가시도 해결했습니다.


## ✅ 변경사항

- 헬스킷에서 `오른 층수`도 권한을 받도록 추가하였습니다.
- 대시보드에서 `운동 시간` 셀을 삭제 · `운동 시간` 셀을 삭제하였습니다.

> 이외 동작은 기존 데이터와 모두 동일합니다. 표시되는 데이터 유형만 달라졌습니다.

- 대시보드에서 권한 변경에 따라 실시간 리로드 로직을 개선하였습니다.

> 기존에는 `SceneDelegate` → `대시보드`로 곧바로 권한 변경 신호를 받았지만, 이제는 `SceneDelegate` → `프로필` → `대시보드`로 거치도록 개선하였습니다. 이는 유저 디폴츠의 `HealthKitLinked` 값이 확실히 변경된 다음, 대시보드에서 리로드를 하기 위함입니다.

@haejaejoon 

- 프로필 화면에 진입하면(viewDidLoad) 건강 데이터 권한 상태를 검사하는 로직을 추가하였습니다.

- 대시보드 하단 셀의 프로그래스 바의 dot이 정확한 지점에 위치하지 않을 수 있는 문제를 수정했습니다.

- 대시보드에서 액티비티 링에 이상한 실선이 생기는 문제를 해결했습니다. (이미지 참조)

---

## ⚠️ 테스트 사항

- 앱을 완전히 종료한 뒤, 건강 데이터 권한을 바꾸고 다시 켜도 프로필 화면의 권한 스위치가 제대로 연동되는지 여부


## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|   <img width="1179" height="2556" alt="IMG_0541" src="https://github.com/user-attachments/assets/f64f831a-b14e-468b-b766-6554fc9efc02" /> |  <img width="1179" height="2556" alt="IMG_0542" src="https://github.com/user-attachments/assets/d1cd856d-d582-4917-888f-50b97988cc6a" />   |
|  <img width="1640" height="2360" alt="Simulator Screenshot - iPad Air 11-inch (M3) - 2025-08-27 at 20 15 04" src="https://github.com/user-attachments/assets/15bab6af-508d-48d4-b1e3-8bbfe062b37d" /> |  |


| 개선 전 | 개선 후 |
| :--: | :--: |
| <img width="1179" height="2556" alt="IMG_0544" src="https://github.com/user-attachments/assets/af9e53e8-313b-4de0-9939-410587463050" /> | <img width="1179" height="2556" alt="IMG_0545" src="https://github.com/user-attachments/assets/01c681ff-6ea0-494f-b457-799f13a86f63" /> |




