### PR TITLE
feat: 날짜가 바뀌면 정확한 목표 걸음 수를 제대로 가져오지 못하는 문제 수정

### DIFF
--- a/Health/Core/Utils/Extensions/Date+Extension.swift
+++ b/Health/Core/Utils/Extensions/Date+Extension.swift
@@ -212,7 +212,7 @@ extension Date {
         let startDate = calendar.dateComponents([.year, .month], from: self)
         let endDate = calendar.dateComponents([.year, .month], from: date)
         let monthDiff = calendar.dateComponents([.month], from: startDate, to: endDate).month!
-        return abs(monthDiff)
+        return abs(monthDiff) + 1
     }
 
     /// 지정된 구성 요소에 일치하는 다음 날짜를 반환합니다.

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -165,7 +165,7 @@ private extension CalendarViewController {
 
     func navigationToDashboard(with date: Date) {
         let dashboardVC = DashboardViewController.instantiateInitialViewController(name: "Dashboard")
-        dashboardVC.viewModel = DashboardViewModel(anchorDate: date)
+        dashboardVC.viewModel = DashboardViewModel(anchorDate: date, fromCalendar: true)
 
         // push 시 탭바가 잠깐 보였다 내려가는 문제로 미리 tabBar를 숨깁니다.
         // pop 해서 DashboardVC가 사라지면 다시 `hidesBottomBarWhenPushed = false`인 화면이 되므로

--- a/Health/Presentation/Dashboard/Content/Enum/DashboardCardKind.swift
+++ b/Health/Presentation/Dashboard/Content/Enum/DashboardCardKind.swift
@@ -147,10 +147,10 @@ extension DashboardCardKind {
         switch age {  // higher is better
         case (..<20):   return [1.0, 1.2, 1.4, 1.6]     // 10대
         case (20..<30): return [1.0, 1.2, 1.4, 1.6]     // 20대
-        case (30..<40): return [0.95, 1.15, 1.35, 1.55] // 30대
+        case (30..<40): return [0.9, 1.1, 1.3, 1.5]     // 30대
         case (40..<50): return [0.9, 1.1, 1.3, 1.5]     // 40대
-        case (50..<60): return [0.75, 1.0, 1.25, 1.5]   // 50대
-        case (60..<70): return [0.7, 0.9, 1.1, 1.3]     // 60대
+        case (50..<60): return [0.8, 1.0, 1.2, 1.4]     // 50대
+        case (60..<70): return [0.8, 1.0, 1.2, 1.4]     // 60대
         default: return [0.6, 0.8, 1.0, 1.2]            // 70대
         }
     }

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -21,7 +21,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
     //
     private var hasBuiltLayout = false
     private var hasLoadedData = false
-    
+
     lazy var viewModel: DashboardViewModel = {
         .init()
     }()

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -65,7 +65,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         // 처음 데이터를 불러오고, 캘린더에서 대시보드로 이동하였다면
         guard !hasLoadedData && viewModel.fromCalendar else { return }
 
-        viewModel.loadHKData()
+        viewModel.loadHKData(updateAnchorDate: true)
         hasLoadedData = true
     }
 

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -36,6 +36,7 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
 
         buildLayout()
 //        loadData() // 생명주기 메서드에서 데이터를 로드하는 대신, 프로필 화면에서 노티피케이션 신호를 받으면 데이터를 로드합니다.
+        loadDataIfNeeded()
         setupDataSource()
         applySnapshot()
 
@@ -60,8 +61,9 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         hasBuiltLayout = true
     }
 
-    private func loadData() {
-        guard !hasLoadedData else { return }
+    private func loadDataIfNeeded() {
+        // 처음 데이터를 불러오고, 캘린더에서 대시보드로 이동하였다면
+        guard !hasLoadedData && viewModel.fromCalendar else { return }
 
         viewModel.loadHKData()
         hasLoadedData = true

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -109,6 +109,13 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(refreshHKData),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshHKData),
             name: .didUpdateGoalStepCount,
             object: nil
         )
@@ -135,6 +142,11 @@ final class DashboardViewController: HealthNavigationController, Alertable, Scro
     }
 
     @objc private func refreshHKData() {
+        // 캘린더에서 대시보드로 이동하였다면 날짜 갱신을 불허합니다.
+        if !viewModel.fromCalendar {
+            viewModel.updateAnchorDate(.now)
+        }
+
         viewModel.loadHKData(includeAI: true, updateAnchorDate: true)
         Task.detached { await self.viewModel.updateWidgetSnapshot() }
         Task.delay(for: 0.6) { @MainActor in refreshControl.endRefreshing() }

--- a/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
+++ b/Health/Presentation/Dashboard/Views/Cells/HealthInfoCardCollectionViewCell.swift
@@ -123,7 +123,7 @@ extension HealthInfoCardCollectionViewCell {
             let hkValue = {
                 switch viewModel.itemID.kind {
                 case .walkingSpeed, .walkingStepLength:
-                    return content.value
+                    return (content.value * 10).rounded() / 10.0
                 case .walkingAsymmetryPercentage, .walkingDoubleSupportPercentage:
                     return content.value * 100.0
                 }

--- a/Health/Services/PromptBuilderService/DefaultPromptBuilderService.swift
+++ b/Health/Services/PromptBuilderService/DefaultPromptBuilderService.swift
@@ -71,6 +71,7 @@ final class DefaultPromptBuilderService: PromptBuilderService {
 
         var prompt = promptTemplateRenderService.render(with: ctx, option: option)
         prompt.append(extraInstructions ?? "")
+        print("생성된 프롬프트:", prompt)
         return prompt
     }
 }

--- a/Health/Services/StepSync/StepSyncService.swift
+++ b/Health/Services/StepSync/StepSyncService.swift
@@ -74,11 +74,6 @@ final class DefaultStepSyncService: StepSyncService {
 
 private extension DefaultStepSyncService {
 
-    func countDailyStep() -> Int {
-        let request = DailyStepEntity.fetchRequest()
-        return (try? CoreDataStack.shared.viewContext.count(for: request)) ?? 0
-    }
-
     /// 가장 이른 목표 걸음 수 설정 날짜를 조회합니다.
     ///
     /// Core Data에서 `GoalStepCountEntity`의 가장 이른 `effectiveDate`를 찾아 반환합니다.

--- a/Health/ViewModels/AlanViewModel.swift
+++ b/Health/ViewModels/AlanViewModel.swift
@@ -23,6 +23,7 @@ final class AlanViewModel {
 			errorMessage = nil
 			return response.content
 		} catch {
+            print("앨런 AI 요청 실패:", error.localizedDescription)
 			errorMessage = error.localizedDescription
 			return nil
 		}
@@ -35,6 +36,7 @@ final class AlanViewModel {
 			_ = try await networkService.request(endpoint: endpoint, as: AlanResetStateResponse.self)
 			errorMessage = nil
 		} catch {
+            print("앨런 AI 상태 초기화 실패:", error.localizedDescription)
 			errorMessage = error.localizedDescription
 		}
 	}

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -194,7 +194,9 @@ extension DashboardViewModel {
 
     func loadAnchorDateForTopCell(updateAnchorDate: Bool) {
         for (_, vm) in topCells {
-            vm.updateAnchorDate(updateAnchorDate ? .now : anchorDate)
+            if updateAnchorDate {
+                vm.updateAnchorDate(fromCalendar ? anchorDate : .now)
+            }
         }
     }
 
@@ -434,7 +436,6 @@ extension DashboardViewModel {
         // ⚠️ 사용자 및 목표 걸음 수가 제대로 등록되어 있으면 않으면 크래시
         let user = try! coreDataUserService.fetchUserInfo()
         let goalStep = dailyStepService.fetchDailyStep(anchorDate)
-        print("GoalStep", goalStep?.goalStepCount)
         return (Int(user.age), Int(goalStep?.goalStepCount ?? 1_000))
 
 //        return (27, 5000)

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -357,7 +357,12 @@ extension DashboardViewModel {
                             else { continue }
 
                             // 특정 날짜에 해당하는 데이터가 없다면
-                            if contents.first(where: { $0.date.isEqual(with: offsetDate) }) == nil {
+                            if contents.first(where: {
+                                switch id.kind {
+                                case .daysBack:   return $0.date.isEqual(with: offsetDate)
+                                case .monthsBack: return $0.date.isEqual([.year, .month], with: offsetDate)
+                                }
+                            }) == nil {
                                 contents.append(DashboardChartsContent(date: offsetDate, value: 0.0))
                             }
                         }

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -17,6 +17,7 @@ final class DashboardViewModel {
 
     private(set) var anchorDate: Date
     let fromCalendar: Bool
+    private var hkDataLoadingInProgress: Bool = false
 
     private(set) var topIDs: [DashboardTopBarViewModel.ItemID] = []
     private(set) var topCells: [DashboardTopBarViewModel.ItemID: DashboardTopBarViewModel] = [:]
@@ -186,6 +187,12 @@ final class DashboardViewModel {
 extension DashboardViewModel {
 
     func loadHKData(includeAI: Bool = true, updateAnchorDate: Bool = false) {
+        guard !hkDataLoadingInProgress else { return }
+        hkDataLoadingInProgress = true
+        defer {
+            hkDataLoadingInProgress = false
+        }
+
         loadAnchorDateForTopCell(updateAnchorDate: updateAnchorDate)
         loadHKDataForActivityRingCells()
         loadHKDataForStackCells()

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -16,6 +16,7 @@ final class DashboardViewModel {
     }
 
     let anchorDate: Date
+    let fromCalendar: Bool
 
     private(set) var topIDs: [DashboardTopBarViewModel.ItemID] = []
     private(set) var topCells: [DashboardTopBarViewModel.ItemID: DashboardTopBarViewModel] = [:]
@@ -50,8 +51,9 @@ final class DashboardViewModel {
     @Injected private var promptBuilderService: (any PromptBuilderService)
 
     ///
-    init(anchorDate: Date = .now) {
+    init(anchorDate: Date = .now, fromCalendar: Bool = false) {
         self.anchorDate = anchorDate
+        self.fromCalendar = fromCalendar
     }
 
 
@@ -432,7 +434,7 @@ extension DashboardViewModel {
         // ⚠️ 사용자 및 목표 걸음 수가 제대로 등록되어 있으면 않으면 크래시
         let user = try! coreDataUserService.fetchUserInfo()
         let goalStep = dailyStepService.fetchDailyStep(anchorDate)
-        
+        print("GoalStep", goalStep?.goalStepCount)
         return (Int(user.age), Int(goalStep?.goalStepCount ?? 1_000))
 
 //        return (27, 5000)

--- a/Health/ViewModels/Dashboard/DashboardViewModel.swift
+++ b/Health/ViewModels/Dashboard/DashboardViewModel.swift
@@ -15,7 +15,7 @@ final class DashboardViewModel {
         let horizontalClassIsRegular: Bool
     }
 
-    let anchorDate: Date
+    private(set) var anchorDate: Date
     let fromCalendar: Bool
 
     private(set) var topIDs: [DashboardTopBarViewModel.ItemID] = []
@@ -54,6 +54,12 @@ final class DashboardViewModel {
     init(anchorDate: Date = .now, fromCalendar: Bool = false) {
         self.anchorDate = anchorDate
         self.fromCalendar = fromCalendar
+    }
+
+    // MARK - Update Anchor Date
+
+    func updateAnchorDate(_ date: Date) {
+        anchorDate = date
     }
 
 

--- a/Health/ViewModels/EntityViewModels/DailyStepViewModel.swift
+++ b/Health/ViewModels/EntityViewModels/DailyStepViewModel.swift
@@ -47,9 +47,10 @@ final class DailyStepViewModel: ObservableObject {
     }
 
     func fetchDailyStep(_ date: Date) -> DailyStepEntity? {
-        let (startOfDay, endOfDay) = date.rangeOfDay()
+        let startOfDay = date.startOfDay()
         let request: NSFetchRequest<DailyStepEntity> = DailyStepEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "date >= %@ AND date < %@", startOfDay as NSDate, endOfDay as NSDate)
+        request.predicate = NSPredicate(format: "date <= %@", startOfDay as NSDate)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \DailyStepEntity.date, ascending: false)]
         request.fetchLimit = 1
 
         do {


### PR DESCRIPTION
## ✅ 변경사항

- 캘린더에서 대시보드로 이동 시, 데이터가 불러오지 못하는 문제를 수정하였습니다.
- 날짜가 바뀌면 대시보드에서 해당 일에 맞는 정확한 목표 걸음 수를 가져오지 못하는 문제를 수정하였습니다.
- 나이대 별로 `보행 속도` 기준점을 수정하였습니다. (막대 프로그래스 바의 정확성을 위해)
- 캘린더에서 이동한 대시보드 화면에서 Pull-to-Refresh 시, 기준 날짜가 엉뚱하게 표시되는 문제 수정하였습니다.

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |
|  <img width="1179" height="2556" alt="IMG_0546" src="https://github.com/user-attachments/assets/1deae6c1-aa52-465b-9004-db540f5f75f1" />  |   <img width="1179" height="2556" alt="IMG_0547" src="https://github.com/user-attachments/assets/9bdeca42-b8f4-4a2e-bef2-8011ad600cc3" />  |
|  <img width="1179" height="2556" alt="IMG_0548" src="https://github.com/user-attachments/assets/840637ff-ccf3-47cd-9604-8ff80d5cc4d5" />  |   <img width="1179" height="2556" alt="IMG_0549" src="https://github.com/user-attachments/assets/92040bc9-4f4c-4087-b05c-62c95e238f07" />  |

* 해당 날짜에 맞는 목표 걸음 수를 가져오는지 테스트하였습니다. 

https://github.com/user-attachments/assets/c78ff3eb-c7c1-4526-b3d4-b44aac641ea8

* 목표 걸음 수가 바뀌면 대시보드에서 잘 갱신되는지 테스트하였습니다.