### PR TITLE
feat: iPad 가로일때 Alert Height 조절

### DIFF
--- a/Health/Core/Protocols/Alertable.swift
+++ b/Health/Core/Protocols/Alertable.swift
@@ -334,7 +334,7 @@ extension Alertable where Self: UIViewController {
         buildView: () -> UIView,
         height: CGFloat = 400,
         width: CGFloat = 500,
-        iPadLandscapeHeight: CGFloat = 700,
+        iPadLandscapeHeight: CGFloat = 500,
         iPadLandscapeWidth: CGFloat = 700,
         iPadPortraitHeight: CGFloat = 500,
         iPadPortraitWidth: CGFloat = 700,

--- a/Health/Presentation/Profile/BodyInfoViewController.swift
+++ b/Health/Presentation/Profile/BodyInfoViewController.swift
@@ -382,6 +382,7 @@ extension BodyInfoViewController: UITableViewDelegate {
                 },
                 height: 600,
                 width: 800,
+                iPadLandscapeHeight: 700,
                 iPadLandscapeWidth: 700,
                 onConfirm: { [weak self] view in
                     guard let self, let v = view as? EditDiseaseView else { return }


### PR DESCRIPTION

## ✅ 변경사항

- 아이패드 가로모드일때 얼럿 높이조절 해서 여백을 줄였습니다

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지
<img width="2732" height="2048" alt="IMG_0031 2" src="https://github.com/user-attachments/assets/d0085ea2-f55c-4cd4-8c3e-89470294c0c5" />


---

### 💜 결과

-
