### PR TITLE
fix: 캘린더 탭 달력 날짜 셀에 다크모드일 때도 테두리 스트로크 추가

### DIFF
--- a/Health/Presentation/Calendar/Views/CalendarDateCell.swift
+++ b/Health/Presentation/Calendar/Views/CalendarDateCell.swift
@@ -141,10 +141,10 @@ private extension CalendarDateCell {
     }
 
     func updateBorderLayer() {
-        let shouldShowBorder = traitCollection.userInterfaceStyle == .light && isSelectable && !isCompleted
+        let shouldShowBorder = isSelectable && !isCompleted
 
         if shouldShowBorder {
-            let borderWidth = bounds.width * 0.08
+            let borderWidth = circleView.bounds.width * 0.08
             let radius = (min(circleView.bounds.width, circleView.bounds.height) - borderWidth) / 2
             let path = UIBezierPath(
                 arcCenter: CGPoint(x: circleView.bounds.midX, y: circleView.bounds.midY),
@@ -155,7 +155,7 @@ private extension CalendarDateCell {
             )
 
             borderLayer.path = path.cgPath
-            borderLayer.strokeColor = UIColor(named: "boxBgLightModeStrokeColor")?.cgColor
+            borderLayer.strokeColor = UIColor(named: "calendarDateStrokeColor")?.cgColor
             borderLayer.fillColor = UIColor.clear.cgColor
             borderLayer.lineWidth = borderWidth
             borderLayer.isHidden = false

--- a/Health/Resources/Assets.xcassets/calendarDateStrokeColor.colorset/Contents.json
+++ b/Health/Resources/Assets.xcassets/calendarDateStrokeColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xD8",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x56",
+          "green" : "0x4B",
+          "red" : "0x4A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 작업내용
- 다크모드일 때도 달력 날짜 셀에 테두리 추가
- 테두리와 프로그레스 바의 너비 일치시키기

## 스크린샷
| Before | After |
| -- | -- |
| <img width="331" height="344" alt="image" src="https://github.com/user-attachments/assets/ece125b6-0e8b-44be-abca-49010b812eb5" /> | <img width="340" height="348" alt="image" src="https://github.com/user-attachments/assets/54b8a758-c229-4797-b25f-7992a6e93a38" /> |