### PR TITLE
fix:Personal-위치권한 없을 때 가까운순 필터링 비활성화

### DIFF
--- a/Health/Presentation/Personal/PersonalViewController.swift
+++ b/Health/Presentation/Personal/PersonalViewController.swift
@@ -151,6 +151,11 @@ class PersonalViewController: HealthNavigationController, Alertable, ScrollableT
 
     private func createWalkingFilterRegistration() -> UICollectionView.CellRegistration<WalkingFilterCell, Void> {
         UICollectionView.CellRegistration<WalkingFilterCell, Void>(cellNib: WalkingFilterCell.nib) { cell, indexPath, _ in
+
+            // 현재 위치권한 상태를 셀에 전달
+            let isLocationGranted = LocationPermissionService.shared.checkCurrentPermissionStatus()
+            cell.updateLocationPermission(isLocationGranted)
+
             // 필터 선택 시 실행될 클로저 설정
             cell.onFilterSelected = { [weak self] selectedFilter in
                 // 어떤 필터가 눌리든 applySorting 함수를 호출하도록 단순화
@@ -448,6 +453,11 @@ class PersonalViewController: HealthNavigationController, Alertable, ScrollableT
         if previousLocationPermission != currentPermission {
             // 현재 상태를 먼저 저장하여 중복 실행 방지
             previousLocationPermission = currentPermission
+
+            // 필터셀의 위치권한 상태 업데이트
+            if let filterCell = collectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? WalkingFilterCell {
+                filterCell.updateLocationPermission(currentPermission)
+            }
 
             Task { @MainActor in
                 distanceViewModel.clearDistanceCache()

--- a/Health/Presentation/Personal/PersonalViewController.swift
+++ b/Health/Presentation/Personal/PersonalViewController.swift
@@ -454,6 +454,13 @@ class PersonalViewController: HealthNavigationController, Alertable, ScrollableT
             // 현재 상태를 먼저 저장하여 중복 실행 방지
             previousLocationPermission = currentPermission
 
+            // 위치권한이 해제되었고, 현재 정렬이 "가까운 순"인 경우 "코스 길이 순"으로 변경
+            if !currentPermission && currentSortType == "가까운 순" {
+                currentSortType = "코스 길이 순"
+                // 코스 길이 순으로 다시 정렬
+                applySorting(sortType: "코스 길이 순")
+            }
+
             // 필터셀의 위치권한 상태 업데이트
             if let filterCell = collectionView.cellForItem(at: IndexPath(item: 0, section: 1)) as? WalkingFilterCell {
                 filterCell.updateLocationPermission(currentPermission)

--- a/Health/Presentation/Personal/Views/MainView/WalkingFilterCell.swift
+++ b/Health/Presentation/Personal/Views/MainView/WalkingFilterCell.swift
@@ -35,28 +35,45 @@ class WalkingFilterCell: CoreCollectionViewCell {
 
         // 메뉴 선택 시 실행될 액션
         let actionHandler: (UIAction) -> Void = { [weak self] action in
-            print("'\(action.title)' 선택됨")
+
+            // 비활성화된 항목은 선택되지 않도록 함
+            guard action.attributes != .disabled else {
+                return
+            }
 
             // PersonalViewController에게 어떤 필터가 선택되었는지 알려줌
             self?.onFilterSelected?(action.title)
         }
 
-        // 메뉴에 맞춰 액션을 생성.
-        let actions = [
-            UIAction(title: "코스 길이 순", handler: actionHandler),
-            UIAction(title: "가까운 순", handler: actionHandler)
-        ]
+        // 현재 위치 권한 상태 확인
+        let isLocationGranted = LocationPermissionService.shared.checkCurrentPermissionStatus()
 
-        // 액션들로 메뉴를 생성.
+        // "코스 길이 순" 액션 (항상 활성화)
+        let courseLengthAction = UIAction(title: "코스 길이 순", handler: actionHandler)
+
+        // "가까운 순" 액션 (위치 권한에 따라 활성화/비활성화)
+        let nearbyAction: UIAction
+        if isLocationGranted {
+            nearbyAction = UIAction(title: "가까운 순", handler: actionHandler)
+        } else {
+            nearbyAction = UIAction(title: "가까운 순", attributes: .disabled, handler: actionHandler)
+        }
+
+        // 액션들로 메뉴를 생성
+        let actions = [courseLengthAction, nearbyAction]
         let menu = UIMenu(children: actions)
 
         // 버튼에 메뉴를 설정하고, 주요 속성들을 설정
         toggleButton.menu = menu
         toggleButton.showsMenuAsPrimaryAction = true
 
-        //메뉴 항목 선택 시 버튼의 제목이 자동으로 변경
+        // 메뉴 항목 선택 시 버튼의 제목이 자동으로 변경
         toggleButton.changesSelectionAsPrimaryAction = true
+    }
 
+    func updateLocationPermission(_ isGranted: Bool) {
+        // 메뉴를 다시 설정해서 권한 상태에 맞게 업데이트
+        setupPullDownMenu()
     }
 }
 


### PR DESCRIPTION
## #️⃣ 이슈번호

> ex) close#IssueNumber, close#IssueNumber

---

## ✅ 변경사항

- 위치 권한 없을 때 가까운 순 필터링 버튼을 비활성화 했습니다.

---

## 🧪 테스트시 유의 사항

- 

---

## 📝 참고

- 

---

## 🌈 이미지

| 1  | 2   |
| :-:| :-: |

https://github.com/user-attachments/assets/8401384b-5575-4d71-8e14-d8c27c077566


|    |     |

---

### 💜 결과

-
